### PR TITLE
fix(daemon): re-entry deadlock, busy-wait, signal safety, and 10 more review fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ ccr-eval/benchmarks/reports/sigmap-reference.json
 ccr-eval/benchmarks/reports/retrieval-baseline.json
 ccr-eval/benchmarks/indexes/
 ccr-eval/benchmarks/repos/
+
+# AgentOps session artifacts
+.agents/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,6 +1970,7 @@ dependencies = [
  "clap",
  "dirs 5.0.1",
  "hex",
+ "libc",
  "once_cell",
  "owo-colors",
  "panda-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,6 +1992,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "fastembed",
+ "libc",
  "once_cell",
  "regex",
  "rusqlite",

--- a/ccr-core/Cargo.toml
+++ b/ccr-core/Cargo.toml
@@ -12,6 +12,7 @@ anyhow.workspace = true
 thiserror.workspace = true
 tiktoken-rs.workspace = true
 once_cell = "1"
+libc = "0.2"
 fastembed = "4"
 rusqlite = { version = "0.31", features = ["bundled"] }
 walkdir = "2"

--- a/ccr-core/src/config.rs
+++ b/ccr-core/src/config.rs
@@ -101,6 +101,10 @@ pub struct GlobalConfig {
     /// experts when one expert exceeds 70% of activations. Prevents expert collapse.
     #[serde(default)]
     pub router_exploration_noise: bool,
+    /// Unix nice level for the panda process. Higher = lower priority.
+    /// Default 10. Set to 0 to disable.
+    #[serde(default = "default_nice_level")]
+    pub nice_level: i32,
 }
 
 fn default_input_char_ceiling() -> usize {
@@ -113,6 +117,10 @@ fn default_output_char_cap() -> usize {
 
 fn default_bert_model() -> String {
     "AllMiniLML6V2".to_string()
+}
+
+fn default_nice_level() -> i32 {
+    10
 }
 
 fn default_state_commands() -> Vec<String> {
@@ -139,6 +147,7 @@ impl Default for GlobalConfig {
             output_char_cap: default_output_char_cap(),
             use_router: false,
             router_exploration_noise: false,
+            nice_level: default_nice_level(),
         }
     }
 }

--- a/ccr-core/src/embed_client.rs
+++ b/ccr-core/src/embed_client.rs
@@ -1,32 +1,30 @@
 use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
+static SOCKET_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+fn socket_dir() -> &'static PathBuf {
+    SOCKET_DIR.get_or_init(|| {
+        if let Ok(runtime_dir) = std::env::var("XDG_RUNTIME_DIR") {
+            PathBuf::from(runtime_dir).join("panda")
+        } else {
+            let uid = unsafe { libc::getuid() };
+            PathBuf::from(format!("/tmp/panda-{}", uid))
+        }
+    })
+}
+
 pub fn socket_path() -> PathBuf {
-    if let Ok(runtime_dir) = std::env::var("XDG_RUNTIME_DIR") {
-        PathBuf::from(runtime_dir).join("panda").join("embed.sock")
-    } else if let Ok(uid) = std::env::var("UID").or_else(|_| {
-        std::process::Command::new("id")
-            .arg("-u")
-            .output()
-            .ok()
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .map(|s| s.trim().to_string())
-            .ok_or(std::env::VarError::NotPresent)
-    }) {
-        PathBuf::from(format!("/tmp/panda-{}", uid)).join("embed.sock")
-    } else {
-        PathBuf::from("/tmp/panda-embed.sock")
-    }
+    socket_dir().join("embed.sock")
 }
 
 pub fn pid_path() -> PathBuf {
-    let mut p = socket_path();
-    p.set_file_name("embed.pid");
-    p
+    socket_dir().join("embed.pid")
 }
 
 pub fn daemon_embed(texts: &[&str], normalize: bool) -> Option<Vec<Vec<f32>>> {
@@ -97,17 +95,12 @@ fn send_request(
 }
 
 fn try_auto_start() {
-    let pid = pid_path();
-    if pid.exists() {
-        // Daemon may be starting up — don't spawn another
-        return;
-    }
-
     let exe = match std::env::current_exe() {
         Ok(e) => e,
         Err(_) => return,
     };
 
+    // `daemon start` is idempotent — it checks liveness and exits if already running.
     let _ = std::process::Command::new(exe)
         .args(["daemon", "start"])
         .stdin(std::process::Stdio::null())

--- a/ccr-core/src/embed_client.rs
+++ b/ccr-core/src/embed_client.rs
@@ -1,0 +1,117 @@
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::time::Duration;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub fn socket_path() -> PathBuf {
+    if let Ok(runtime_dir) = std::env::var("XDG_RUNTIME_DIR") {
+        PathBuf::from(runtime_dir).join("panda").join("embed.sock")
+    } else if let Ok(uid) = std::env::var("UID").or_else(|_| {
+        std::process::Command::new("id")
+            .arg("-u")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .ok_or(std::env::VarError::NotPresent)
+    }) {
+        PathBuf::from(format!("/tmp/panda-{}", uid)).join("embed.sock")
+    } else {
+        PathBuf::from("/tmp/panda-embed.sock")
+    }
+}
+
+pub fn pid_path() -> PathBuf {
+    let mut p = socket_path();
+    p.set_file_name("embed.pid");
+    p
+}
+
+pub fn daemon_embed(texts: &[&str], normalize: bool) -> Option<Vec<Vec<f32>>> {
+    let sock = socket_path();
+    if !sock.exists() {
+        try_auto_start();
+        return None;
+    }
+
+    let stream = match UnixStream::connect(&sock) {
+        Ok(s) => s,
+        Err(_) => {
+            try_auto_start();
+            return None;
+        }
+    };
+
+    stream.set_read_timeout(Some(REQUEST_TIMEOUT)).ok()?;
+    stream.set_write_timeout(Some(REQUEST_TIMEOUT)).ok()?;
+
+    send_request(stream, texts, normalize)
+}
+
+fn send_request(
+    mut stream: UnixStream,
+    texts: &[&str],
+    normalize: bool,
+) -> Option<Vec<Vec<f32>>> {
+    let request = serde_json::json!({
+        "texts": texts,
+        "normalize": normalize,
+    });
+    let payload = serde_json::to_vec(&request).ok()?;
+
+    // Length-prefixed framing: 4-byte big-endian length + JSON
+    let len = (payload.len() as u32).to_be_bytes();
+    stream.write_all(&len).ok()?;
+    stream.write_all(&payload).ok()?;
+
+    // Read response
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf).ok()?;
+    let resp_len = u32::from_be_bytes(len_buf) as usize;
+
+    if resp_len > 100_000_000 {
+        return None;
+    }
+
+    let mut resp_buf = vec![0u8; resp_len];
+    stream.read_exact(&mut resp_buf).ok()?;
+
+    let resp: serde_json::Value = serde_json::from_slice(&resp_buf).ok()?;
+
+    if resp.get("ok")?.as_bool()? {
+        let embeddings: Vec<Vec<f32>> = resp
+            .get("embeddings")?
+            .as_array()?
+            .iter()
+            .map(|arr| {
+                arr.as_array()
+                    .map(|a| a.iter().filter_map(|v| v.as_f64().map(|f| f as f32)).collect())
+            })
+            .collect::<Option<Vec<Vec<f32>>>>()?;
+        Some(embeddings)
+    } else {
+        None
+    }
+}
+
+fn try_auto_start() {
+    let pid = pid_path();
+    if pid.exists() {
+        // Daemon may be starting up — don't spawn another
+        return;
+    }
+
+    let exe = match std::env::current_exe() {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    let _ = std::process::Command::new(exe)
+        .args(["daemon", "start"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+}

--- a/ccr-core/src/lib.rs
+++ b/ccr-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod ansi;
 pub mod global_rules;
 pub mod config;
 pub mod delta;
+#[cfg(unix)]
 pub mod embed_client;
 pub mod focus;
 pub mod jsonlog;

--- a/ccr-core/src/lib.rs
+++ b/ccr-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod ansi;
 pub mod global_rules;
 pub mod config;
 pub mod delta;
+pub mod embed_client;
 pub mod focus;
 pub mod jsonlog;
 pub mod ndjson;

--- a/ccr-core/src/summarizer.rs
+++ b/ccr-core/src/summarizer.rs
@@ -51,6 +51,29 @@ fn effective_critical_pattern() -> Regex {
 // ── P8: Configurable BERT model ───────────────────────────────────────────────
 
 static MODEL_NAME: OnceCell<String> = OnceCell::new();
+static NICE_LEVEL: OnceCell<i32> = OnceCell::new();
+
+pub fn set_nice_level(level: i32) {
+    let _ = NICE_LEVEL.set(level);
+}
+
+#[cfg(unix)]
+fn apply_nice_once() {
+    static APPLIED: std::sync::Once = std::sync::Once::new();
+    APPLIED.call_once(|| {
+        if let Some(&level) = NICE_LEVEL.get() {
+            if level > 0 {
+                unsafe {
+                    *libc::__errno_location() = 0;
+                    let ret = libc::nice(level);
+                    if ret == -1 && *libc::__errno_location() != 0 {
+                        eprintln!("[panda] warning: nice({}) failed", level);
+                    }
+                }
+            }
+        }
+    });
+}
 
 /// Set the BERT model name to use. Must be called before the first summarization.
 /// First call wins (subsequent calls are no-ops).
@@ -188,16 +211,28 @@ fn compute_centroid(embeddings: &[Vec<f32>]) -> Vec<f32> {
     centroid
 }
 
-fn embed_and_normalize(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
-    if let Some(embeddings) = crate::embed_client::daemon_embed(&texts, true) {
-        return Ok(embeddings);
-    }
+pub fn embed_direct(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
     let model = get_model()?;
     let mut embeddings = model.embed(texts, None)?;
     for emb in &mut embeddings {
         l2_normalize(emb);
     }
     Ok(embeddings)
+}
+
+pub fn embed_raw(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
+    let model = get_model()?;
+    model.embed(texts, None).map_err(Into::into)
+}
+
+fn embed_and_normalize(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
+    #[cfg(unix)]
+    if let Some(embeddings) = crate::embed_client::daemon_embed(&texts, true) {
+        return Ok(embeddings);
+    }
+    #[cfg(unix)]
+    apply_nice_once();
+    embed_direct(texts)
 }
 
 // ── Public result types ───────────────────────────────────────────────────────

--- a/ccr-core/src/summarizer.rs
+++ b/ccr-core/src/summarizer.rs
@@ -188,13 +188,11 @@ fn compute_centroid(embeddings: &[Vec<f32>]) -> Vec<f32> {
     centroid
 }
 
-/// Embed `texts` and L2-normalize every output vector.
-/// All downstream similarity calls can then use `dot` instead of full cosine similarity,
-/// eliminating two sqrt calls per pair.
-fn embed_and_normalize(
-    model: &fastembed::TextEmbedding,
-    texts: Vec<&str>,
-) -> anyhow::Result<Vec<Vec<f32>>> {
+fn embed_and_normalize(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
+    if let Some(embeddings) = crate::embed_client::daemon_embed(&texts, true) {
+        return Ok(embeddings);
+    }
+    let model = get_model()?;
     let mut embeddings = model.embed(texts, None)?;
     for emb in &mut embeddings {
         l2_normalize(emb);
@@ -290,14 +288,13 @@ fn summarize_semantic_intent(
         return Ok(lines.join("\n"));
     }
 
-    let model = get_model()?;
 
     // Embed lines + command + intent in one batch
     let mut texts: Vec<&str> = indexed_lines.iter().map(|(_, l)| *l).collect();
     texts.push(command);
     texts.push(intent);
 
-    let all_embeddings = embed_and_normalize(model, texts)?;
+    let all_embeddings = embed_and_normalize(texts)?;
     let n = indexed_lines.len();
     let cmd_emb = &all_embeddings[n];
     let intent_emb = &all_embeddings[n + 1];
@@ -406,7 +403,6 @@ fn summarize_semantic(
         return Ok(lines.join("\n"));
     }
 
-    let model = get_model()?;
 
     // Embed lines + optional query in one batch, L2-normalizing all vectors so
     // downstream similarity calls reduce to plain dot products.
@@ -416,7 +412,7 @@ fn summarize_semantic(
         texts.push(q);
     }
 
-    let all_embeddings = embed_and_normalize(model, texts)?;
+    let all_embeddings = embed_and_normalize(texts)?;
     let query_emb: Option<&Vec<f32>> = if has_query { all_embeddings.last() } else { None };
     let embeddings = if has_query {
         &all_embeddings[..all_embeddings.len() - 1]
@@ -584,9 +580,8 @@ fn summarize_semantic_anchored(
         if let Some(pre) = precomputed.filter(|p| p.len() == n) {
             pre
         } else {
-            let model = get_model()?;
             let texts: Vec<&str> = indexed_lines.iter().map(|(_, l)| *l).collect();
-            embed_and_normalize(model, texts)?
+            embed_and_normalize(texts)?
         };
 
     let centroid = compute_centroid(&embeddings);
@@ -721,16 +716,11 @@ pub fn entropy_adjusted_budget(text: &str, max_budget: usize) -> usize {
         return max_budget;
     }
 
-    let model = match get_model() {
-        Ok(m) => m,
-        Err(_) => return max_budget,
-    };
-
     // Sample up to 100 lines evenly to avoid O(N²) cost on huge inputs
     let step = (lines.len() / 100).max(1);
     let sample: Vec<&str> = lines.iter().step_by(step).copied().collect();
 
-    let embeddings = match embed_and_normalize(model, sample) {
+    let embeddings = match embed_and_normalize(sample) {
         Ok(e) => e,
         Err(_) => return max_budget,
     };
@@ -885,9 +875,8 @@ fn summarize_sentences_semantic(
     budget: usize,
     hard_keep: impl Fn(&str) -> bool,
 ) -> anyhow::Result<String> {
-    let model = get_model()?;
     let texts: Vec<&str> = sentences.iter().map(|s| s.as_str()).collect();
-    let embeddings = embed_and_normalize(model, texts)?;
+    let embeddings = embed_and_normalize(texts)?;
 
     let centroid = compute_centroid(&embeddings);
 
@@ -993,9 +982,8 @@ fn do_cluster_summarize(
         if let Some(pre) = precomputed.filter(|p| p.len() == n) {
             pre
         } else {
-            let model = get_model()?;
             let texts: Vec<&str> = indexed.iter().map(|(_, l)| *l).collect();
-            embed_and_normalize(model, texts)?
+            embed_and_normalize(texts)?
         };
 
     // ── Greedy clustering ────────────────────────────────────────────────────
@@ -1145,9 +1133,8 @@ fn summarize_against_centroid_inner(
         return Ok(lines.join("\n"));
     }
 
-    let model = get_model()?;
     let texts: Vec<&str> = indexed_lines.iter().map(|(_, l)| *l).collect();
-    let embeddings = embed_and_normalize(model, texts)?;
+    let embeddings = embed_and_normalize(texts)?;
 
     // Normalize the historical centroid at the point of use so it is compatible with
     // the unit-length line embeddings regardless of when it was stored (before or after
@@ -1231,19 +1218,13 @@ static NOISE_EMB: OnceCell<Vec<f32>> = OnceCell::new();
 
 fn useful_embedding() -> anyhow::Result<&'static Vec<f32>> {
     USEFUL_EMB.get_or_try_init(|| {
-        let model = get_model()?;
-        let mut emb = model.embed(vec![USEFUL_PROTOTYPE], None)?.remove(0);
-        l2_normalize(&mut emb);
-        Ok(emb)
+        Ok(embed_and_normalize(vec![USEFUL_PROTOTYPE])?.remove(0))
     })
 }
 
 fn noise_embedding() -> anyhow::Result<&'static Vec<f32>> {
     NOISE_EMB.get_or_try_init(|| {
-        let model = get_model()?;
-        let mut emb = model.embed(vec![NOISE_PROTOTYPE], None)?.remove(0);
-        l2_normalize(&mut emb);
-        Ok(emb)
+        Ok(embed_and_normalize(vec![NOISE_PROTOTYPE])?.remove(0))
     })
 }
 
@@ -1258,11 +1239,10 @@ pub fn noise_scores(lines: &[&str]) -> anyhow::Result<Vec<f32>> {
         return Ok(vec![]);
     }
 
-    let model = get_model()?;
     let useful_emb = useful_embedding()?;
     let noise_emb = noise_embedding()?;
 
-    let embeddings = embed_and_normalize(model, lines.to_vec())?;
+    let embeddings = embed_and_normalize(lines.to_vec())?;
 
     let scores = embeddings
         .iter()
@@ -1305,12 +1285,11 @@ pub fn noise_filter_with_embeddings(
         return Ok((lines.iter().map(|s| s.to_string()).collect(), vec![]));
     }
 
-    let model = get_model()?;
     let useful_emb = useful_embedding()?;
     let noise_emb = noise_embedding()?;
 
     let texts: Vec<&str> = non_empty.iter().map(|(_, l)| *l).collect();
-    let embeddings = embed_and_normalize(model, texts)?;
+    let embeddings = embed_and_normalize(texts)?;
 
     // Mark noisy lines for removal
     let mut drop_set: std::collections::HashSet<usize> = std::collections::HashSet::new();
@@ -1344,8 +1323,7 @@ pub fn noise_filter_with_embeddings(
 // ── Batch embedding (public) ──────────────────────────────────────────────────
 
 pub fn embed_batch(texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
-    let model = get_model()?;
-    embed_and_normalize(model, texts.to_vec())
+    embed_and_normalize(texts.to_vec())
 }
 
 /// Compute the mean embedding of all non-empty lines in `text`.
@@ -1393,8 +1371,7 @@ pub fn compute_centroid_from_embeddings(embeddings: &[Vec<f32>]) -> Vec<f32> {
 
 /// Compute semantic similarity between two texts. Used as a quality gate on generative output.
 pub fn semantic_similarity(a: &str, b: &str) -> anyhow::Result<f32> {
-    let model = get_model()?;
-    let embeddings = embed_and_normalize(model, vec![a, b])?;
+    let embeddings = embed_and_normalize(vec![a, b])?;
     Ok(dot(&embeddings[0], &embeddings[1]))
 }
 

--- a/ccr/Cargo.toml
+++ b/ccr/Cargo.toml
@@ -23,6 +23,7 @@ anyhow.workspace = true
 thiserror.workspace = true
 clap.workspace = true
 dirs = "5"
+libc = "0.2"
 owo-colors.workspace = true
 atty = "0.2"
 sha2.workspace = true

--- a/ccr/src/cmd/daemon.rs
+++ b/ccr/src/cmd/daemon.rs
@@ -9,6 +9,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use panda_core::embed_client;
 
 const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 900; // 15 minutes
+const BLOATED_IDLE_TIMEOUT_SECS: u64 = 60;  // 1 minute when RSS is high
+const RSS_BLOAT_THRESHOLD_MB: u64 = 500;
 
 #[derive(clap::Subcommand)]
 pub enum DaemonAction {
@@ -33,6 +35,14 @@ fn now_secs() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+fn current_rss_mb() -> u64 {
+    std::fs::read_to_string(format!("/proc/{}/statm", std::process::id()))
+        .ok()
+        .and_then(|s| s.split_whitespace().nth(1)?.parse::<u64>().ok())
+        .map(|pages| pages * 4096 / 1024 / 1024)
+        .unwrap_or(0)
 }
 
 fn ensure_dir(path: &Path) {
@@ -199,12 +209,20 @@ fn daemon_main(sock_path: PathBuf, pid_path: PathBuf) -> Result<()> {
     };
 
     // Idle timeout watchdog — sends SIGTERM to self to unblock poll().
+    // Uses a shorter timeout when RSS is high so the daemon shuts down quickly
+    // after a large embedding batch. Auto-start will spin up a fresh ~180MB
+    // daemon on the next request.
     let lr = last_request.clone();
     std::thread::spawn(move || {
         loop {
-            std::thread::sleep(Duration::from_secs(30));
+            std::thread::sleep(Duration::from_secs(10));
             let idle = now_secs().saturating_sub(lr.load(Ordering::Relaxed));
-            if idle > DEFAULT_IDLE_TIMEOUT_SECS {
+            let timeout = if current_rss_mb() > RSS_BLOAT_THRESHOLD_MB {
+                BLOATED_IDLE_TIMEOUT_SECS
+            } else {
+                DEFAULT_IDLE_TIMEOUT_SECS
+            };
+            if idle > timeout {
                 unsafe { libc::kill(libc::getpid(), libc::SIGTERM) };
                 break;
             }

--- a/ccr/src/cmd/daemon.rs
+++ b/ccr/src/cmd/daemon.rs
@@ -1,0 +1,306 @@
+use anyhow::{bail, Result};
+use std::io::{Read, Write};
+use std::os::unix::net::UnixListener;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use panda_core::embed_client;
+
+const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 900; // 15 minutes
+
+#[derive(clap::Subcommand, Clone)]
+pub enum DaemonAction {
+    /// Start the embedding daemon in the background
+    Start,
+    /// Stop the embedding daemon
+    Stop,
+    /// Show daemon status
+    Status,
+}
+
+pub fn run(action: DaemonAction) -> Result<()> {
+    match action {
+        DaemonAction::Start => start(),
+        DaemonAction::Stop => stop(),
+        DaemonAction::Status => status(),
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn ensure_dir(path: &PathBuf) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+}
+
+fn read_pid() -> Option<u32> {
+    let content = std::fs::read_to_string(embed_client::pid_path()).ok()?;
+    content.trim().parse().ok()
+}
+
+fn process_alive(pid: u32) -> bool {
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+fn start() -> Result<()> {
+    if let Some(pid) = read_pid() {
+        if process_alive(pid) {
+            println!("panda daemon already running (pid {})", pid);
+            return Ok(());
+        }
+        let _ = std::fs::remove_file(embed_client::pid_path());
+        let _ = std::fs::remove_file(embed_client::socket_path());
+    }
+
+    let sock_path = embed_client::socket_path();
+    let pid_path = embed_client::pid_path();
+    ensure_dir(&sock_path);
+
+    unsafe {
+        let pid = libc::fork();
+        if pid < 0 {
+            bail!("fork failed");
+        }
+        if pid > 0 {
+            std::thread::sleep(Duration::from_millis(200));
+            if let Some(child_pid) = read_pid() {
+                println!("panda daemon started (pid {})", child_pid);
+            } else {
+                println!("panda daemon starting...");
+            }
+            return Ok(());
+        }
+
+        libc::setsid();
+
+        let pid2 = libc::fork();
+        if pid2 < 0 {
+            std::process::exit(1);
+        }
+        if pid2 > 0 {
+            std::process::exit(0);
+        }
+
+        let devnull = libc::open(b"/dev/null\0".as_ptr() as *const _, libc::O_RDWR);
+        if devnull >= 0 {
+            libc::dup2(devnull, 0);
+            libc::dup2(devnull, 1);
+            libc::dup2(devnull, 2);
+            if devnull > 2 {
+                libc::close(devnull);
+            }
+        }
+    }
+
+    daemon_main(sock_path, pid_path)
+}
+
+static SIGTERM_RECEIVED: AtomicBool = AtomicBool::new(false);
+
+extern "C" fn sigterm_handler(_sig: libc::c_int) {
+    SIGTERM_RECEIVED.store(true, Ordering::SeqCst);
+}
+
+fn daemon_main(sock_path: PathBuf, pid_path: PathBuf) -> Result<()> {
+    ensure_dir(&pid_path);
+    std::fs::write(&pid_path, format!("{}", std::process::id()))?;
+
+    let _ = std::fs::remove_file(&sock_path);
+
+    if let Ok(config) = crate::config_loader::load_config() {
+        panda_core::summarizer::set_model_name(&config.global.bert_model);
+    }
+    if let Err(_) = panda_core::summarizer::preload_model() {
+        let _ = std::fs::remove_file(&pid_path);
+        std::process::exit(1);
+    }
+
+    let listener = UnixListener::bind(&sock_path)?;
+    listener.set_nonblocking(true)?;
+
+    unsafe {
+        libc::signal(libc::SIGTERM, sigterm_handler as *const () as libc::sighandler_t);
+    }
+
+    let last_request = Arc::new(AtomicU64::new(now_secs()));
+
+    // Idle timeout watchdog
+    let lr = last_request.clone();
+    std::thread::spawn(move || {
+        loop {
+            std::thread::sleep(Duration::from_secs(30));
+            let idle = now_secs() - lr.load(Ordering::Relaxed);
+            if idle > DEFAULT_IDLE_TIMEOUT_SECS {
+                SIGTERM_RECEIVED.store(true, Ordering::SeqCst);
+                break;
+            }
+        }
+    });
+
+    while !SIGTERM_RECEIVED.load(Ordering::Relaxed) {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                last_request.store(now_secs(), Ordering::Relaxed);
+                handle_connection(stream);
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(_) => break,
+        }
+    }
+
+    let _ = std::fs::remove_file(&sock_path);
+    let _ = std::fs::remove_file(&pid_path);
+    std::process::exit(0);
+}
+
+fn handle_connection(mut stream: std::os::unix::net::UnixStream) {
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(5)));
+
+    let mut len_buf = [0u8; 4];
+    if stream.read_exact(&mut len_buf).is_err() {
+        return;
+    }
+    let req_len = u32::from_be_bytes(len_buf) as usize;
+    if req_len > 10_000_000 {
+        return;
+    }
+
+    let mut req_buf = vec![0u8; req_len];
+    if stream.read_exact(&mut req_buf).is_err() {
+        return;
+    }
+
+    let response = match process_request(&req_buf) {
+        Ok(resp) => resp,
+        Err(e) => serde_json::json!({
+            "ok": false,
+            "error": format!("{}", e),
+        }),
+    };
+
+    let resp_bytes = match serde_json::to_vec(&response) {
+        Ok(b) => b,
+        Err(_) => return,
+    };
+
+    let len = (resp_bytes.len() as u32).to_be_bytes();
+    let _ = stream.write_all(&len);
+    let _ = stream.write_all(&resp_bytes);
+}
+
+fn process_request(req_buf: &[u8]) -> Result<serde_json::Value> {
+    let req: serde_json::Value = serde_json::from_slice(req_buf)?;
+
+    let texts: Vec<String> = req
+        .get("texts")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if texts.is_empty() {
+        return Ok(serde_json::json!({
+            "ok": true,
+            "embeddings": [],
+        }));
+    }
+
+    let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+    let embeddings = panda_core::summarizer::embed_batch(&text_refs)?;
+
+    Ok(serde_json::json!({
+        "ok": true,
+        "embeddings": embeddings,
+    }))
+}
+
+fn stop() -> Result<()> {
+    let pid_path = embed_client::pid_path();
+    let sock_path = embed_client::socket_path();
+
+    let pid = match read_pid() {
+        Some(p) => p,
+        None => {
+            println!("panda daemon is not running");
+            return Ok(());
+        }
+    };
+
+    if !process_alive(pid) {
+        println!("panda daemon is not running (stale pid file)");
+        let _ = std::fs::remove_file(&pid_path);
+        let _ = std::fs::remove_file(&sock_path);
+        return Ok(());
+    }
+
+    unsafe {
+        libc::kill(pid as i32, libc::SIGTERM);
+    }
+
+    for _ in 0..30 {
+        std::thread::sleep(Duration::from_millis(100));
+        if !process_alive(pid) {
+            println!("panda daemon stopped");
+            let _ = std::fs::remove_file(&pid_path);
+            let _ = std::fs::remove_file(&sock_path);
+            return Ok(());
+        }
+    }
+
+    unsafe {
+        libc::kill(pid as i32, libc::SIGKILL);
+    }
+    let _ = std::fs::remove_file(&pid_path);
+    let _ = std::fs::remove_file(&sock_path);
+    println!("panda daemon killed");
+    Ok(())
+}
+
+fn status() -> Result<()> {
+    let pid = match read_pid() {
+        Some(p) => p,
+        None => {
+            println!("panda daemon is not running");
+            return Ok(());
+        }
+    };
+
+    if !process_alive(pid) {
+        println!("panda daemon is not running (stale pid file)");
+        return Ok(());
+    }
+
+    let sock = embed_client::socket_path();
+
+    let rss = std::fs::read_to_string(format!("/proc/{}/statm", pid))
+        .ok()
+        .and_then(|s| {
+            s.split_whitespace()
+                .nth(1)?
+                .parse::<u64>()
+                .ok()
+                .map(|pages| pages * 4096 / 1024 / 1024)
+        });
+
+    println!("panda daemon running (pid {})", pid);
+    println!("  socket: {}", sock.display());
+    if let Some(mb) = rss {
+        println!("  memory: {} MB", mb);
+    }
+
+    Ok(())
+}

--- a/ccr/src/cmd/daemon.rs
+++ b/ccr/src/cmd/daemon.rs
@@ -125,6 +125,10 @@ fn daemon_main(sock_path: PathBuf, pid_path: PathBuf) -> Result<()> {
 
     let _ = std::fs::remove_file(&sock_path);
 
+    // Limit Rayon's global thread pool to 1 thread — the daemon serves requests
+    // sequentially, so parallel batch processing just wastes memory.
+    std::env::set_var("RAYON_NUM_THREADS", "1");
+
     // Apply nice level inside the daemon process only.
     if let Ok(config) = crate::config_loader::load_config() {
         #[cfg(unix)]
@@ -139,9 +143,35 @@ fn daemon_main(sock_path: PathBuf, pid_path: PathBuf) -> Result<()> {
         }
         panda_core::summarizer::set_model_name(&config.global.bert_model);
     }
+
+    // fastembed sets ONNX intra-op threads to available_parallelism(), which on
+    // Linux reads sched_getaffinity. Restrict to 2 CPUs before model init so ONNX
+    // creates 2 threads instead of all cores — cuts idle RSS from ~2GB to ~200MB.
+    // Restore full affinity afterwards so the daemon isn't CPU-pinned during inference.
+    #[cfg(unix)]
+    let saved_affinity = unsafe {
+        let mut old: libc::cpu_set_t = std::mem::zeroed();
+        libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut old);
+
+        let mut restricted: libc::cpu_set_t = std::mem::zeroed();
+        libc::CPU_SET(0, &mut restricted);
+        libc::CPU_SET(1, &mut restricted);
+        libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &restricted);
+        old
+    };
+
     if panda_core::summarizer::preload_model().is_err() {
         let _ = std::fs::remove_file(&pid_path);
         std::process::exit(1);
+    }
+
+    #[cfg(unix)]
+    unsafe {
+        libc::sched_setaffinity(
+            0,
+            std::mem::size_of::<libc::cpu_set_t>(),
+            &saved_affinity,
+        );
     }
 
     // Set restrictive permissions before binding the socket.

--- a/ccr/src/cmd/daemon.rs
+++ b/ccr/src/cmd/daemon.rs
@@ -1,8 +1,8 @@
 use anyhow::{bail, Result};
 use std::io::{Read, Write};
 use std::os::unix::net::UnixListener;
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -10,7 +10,7 @@ use panda_core::embed_client;
 
 const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 900; // 15 minutes
 
-#[derive(clap::Subcommand, Clone)]
+#[derive(clap::Subcommand)]
 pub enum DaemonAction {
     /// Start the embedding daemon in the background
     Start,
@@ -35,7 +35,7 @@ fn now_secs() -> u64 {
         .as_secs()
 }
 
-fn ensure_dir(path: &PathBuf) {
+fn ensure_dir(path: &Path) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
@@ -47,7 +47,13 @@ fn read_pid() -> Option<u32> {
 }
 
 fn process_alive(pid: u32) -> bool {
-    unsafe { libc::kill(pid as i32, 0) == 0 }
+    let ret = unsafe { libc::kill(pid as i32, 0) };
+    ret == 0 || (ret == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM))
+}
+
+fn cleanup_daemon_files() {
+    let _ = std::fs::remove_file(embed_client::pid_path());
+    let _ = std::fs::remove_file(embed_client::socket_path());
 }
 
 fn start() -> Result<()> {
@@ -56,14 +62,15 @@ fn start() -> Result<()> {
             println!("panda daemon already running (pid {})", pid);
             return Ok(());
         }
-        let _ = std::fs::remove_file(embed_client::pid_path());
-        let _ = std::fs::remove_file(embed_client::socket_path());
+        cleanup_daemon_files();
     }
 
     let sock_path = embed_client::socket_path();
     let pid_path = embed_client::pid_path();
     ensure_dir(&sock_path);
 
+    // Fork early, before any config loading or thread creation, to avoid
+    // UB from forking a multi-threaded Rust process.
     unsafe {
         let pid = libc::fork();
         if pid < 0 {
@@ -89,7 +96,7 @@ fn start() -> Result<()> {
             std::process::exit(0);
         }
 
-        let devnull = libc::open(b"/dev/null\0".as_ptr() as *const _, libc::O_RDWR);
+        let devnull = libc::open(c"/dev/null".as_ptr(), libc::O_RDWR);
         if devnull >= 0 {
             libc::dup2(devnull, 0);
             libc::dup2(devnull, 1);
@@ -103,10 +110,13 @@ fn start() -> Result<()> {
     daemon_main(sock_path, pid_path)
 }
 
-static SIGTERM_RECEIVED: AtomicBool = AtomicBool::new(false);
+static SHUTDOWN_PIPE: std::sync::OnceLock<(i32, i32)> = std::sync::OnceLock::new();
 
 extern "C" fn sigterm_handler(_sig: libc::c_int) {
-    SIGTERM_RECEIVED.store(true, Ordering::SeqCst);
+    // Write a single byte to the pipe — write(2) is async-signal-safe per POSIX.
+    if let Some(&(_, write_fd)) = SHUTDOWN_PIPE.get() {
+        unsafe { libc::write(write_fd, b"x" as *const _ as *const libc::c_void, 1) };
+    }
 }
 
 fn daemon_main(sock_path: PathBuf, pid_path: PathBuf) -> Result<()> {
@@ -115,51 +125,96 @@ fn daemon_main(sock_path: PathBuf, pid_path: PathBuf) -> Result<()> {
 
     let _ = std::fs::remove_file(&sock_path);
 
+    // Apply nice level inside the daemon process only.
     if let Ok(config) = crate::config_loader::load_config() {
+        #[cfg(unix)]
+        if config.global.nice_level > 0 {
+            unsafe {
+                *libc::__errno_location() = 0;
+                let ret = libc::nice(config.global.nice_level);
+                if ret == -1 && *libc::__errno_location() != 0 {
+                    eprintln!("warning: nice({}) failed", config.global.nice_level);
+                }
+            }
+        }
         panda_core::summarizer::set_model_name(&config.global.bert_model);
     }
-    if let Err(_) = panda_core::summarizer::preload_model() {
+    if panda_core::summarizer::preload_model().is_err() {
         let _ = std::fs::remove_file(&pid_path);
         std::process::exit(1);
     }
 
+    // Set restrictive permissions before binding the socket.
+    let old_umask = unsafe { libc::umask(0o077) };
     let listener = UnixListener::bind(&sock_path)?;
-    listener.set_nonblocking(true)?;
+    unsafe { libc::umask(old_umask) };
+    // Blocking listener — no busy-wait.
+
+    // Self-pipe for async-signal-safe shutdown.
+    let mut pipe_fds = [0i32; 2];
+    if unsafe { libc::pipe(pipe_fds.as_mut_ptr()) } != 0 {
+        bail!("pipe() failed");
+    }
+    SHUTDOWN_PIPE.set((pipe_fds[0], pipe_fds[1])).ok();
 
     unsafe {
         libc::signal(libc::SIGTERM, sigterm_handler as *const () as libc::sighandler_t);
+        libc::signal(libc::SIGINT, sigterm_handler as *const () as libc::sighandler_t);
     }
 
     let last_request = Arc::new(AtomicU64::new(now_secs()));
+    let listener_fd = {
+        use std::os::unix::io::AsRawFd;
+        listener.as_raw_fd()
+    };
 
-    // Idle timeout watchdog
+    // Idle timeout watchdog — sends SIGTERM to self to unblock poll().
     let lr = last_request.clone();
     std::thread::spawn(move || {
         loop {
             std::thread::sleep(Duration::from_secs(30));
-            let idle = now_secs() - lr.load(Ordering::Relaxed);
+            let idle = now_secs().saturating_sub(lr.load(Ordering::Relaxed));
             if idle > DEFAULT_IDLE_TIMEOUT_SECS {
-                SIGTERM_RECEIVED.store(true, Ordering::SeqCst);
+                unsafe { libc::kill(libc::getpid(), libc::SIGTERM) };
                 break;
             }
         }
     });
 
-    while !SIGTERM_RECEIVED.load(Ordering::Relaxed) {
-        match listener.accept() {
-            Ok((stream, _)) => {
-                last_request.store(now_secs(), Ordering::Relaxed);
-                handle_connection(stream);
+    // Use poll() to wait on both the listener and the shutdown pipe.
+    let mut pollfds = [
+        libc::pollfd { fd: listener_fd, events: libc::POLLIN, revents: 0 },
+        libc::pollfd { fd: pipe_fds[0], events: libc::POLLIN, revents: 0 },
+    ];
+
+    loop {
+        let ret = unsafe { libc::poll(pollfds.as_mut_ptr(), 2, -1) };
+        if ret < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EINTR) {
+                continue;
             }
-            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                std::thread::sleep(Duration::from_millis(50));
+            break;
+        }
+
+        // Shutdown pipe readable — time to exit.
+        if pollfds[1].revents & libc::POLLIN != 0 {
+            break;
+        }
+
+        // Listener has a connection.
+        if pollfds[0].revents & libc::POLLIN != 0 {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    last_request.store(now_secs(), Ordering::Relaxed);
+                    handle_connection(stream);
+                }
+                Err(_) => break,
             }
-            Err(_) => break,
         }
     }
 
-    let _ = std::fs::remove_file(&sock_path);
-    let _ = std::fs::remove_file(&pid_path);
+    cleanup_daemon_files();
     std::process::exit(0);
 }
 
@@ -219,8 +274,13 @@ fn process_request(req_buf: &[u8]) -> Result<serde_json::Value> {
         }));
     }
 
+    let normalize = req.get("normalize").and_then(|v| v.as_bool()).unwrap_or(true);
     let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
-    let embeddings = panda_core::summarizer::embed_batch(&text_refs)?;
+    let embeddings = if normalize {
+        panda_core::summarizer::embed_direct(text_refs)?
+    } else {
+        panda_core::summarizer::embed_raw(text_refs)?
+    };
 
     Ok(serde_json::json!({
         "ok": true,
@@ -229,9 +289,6 @@ fn process_request(req_buf: &[u8]) -> Result<serde_json::Value> {
 }
 
 fn stop() -> Result<()> {
-    let pid_path = embed_client::pid_path();
-    let sock_path = embed_client::socket_path();
-
     let pid = match read_pid() {
         Some(p) => p,
         None => {
@@ -242,8 +299,7 @@ fn stop() -> Result<()> {
 
     if !process_alive(pid) {
         println!("panda daemon is not running (stale pid file)");
-        let _ = std::fs::remove_file(&pid_path);
-        let _ = std::fs::remove_file(&sock_path);
+        cleanup_daemon_files();
         return Ok(());
     }
 
@@ -255,8 +311,7 @@ fn stop() -> Result<()> {
         std::thread::sleep(Duration::from_millis(100));
         if !process_alive(pid) {
             println!("panda daemon stopped");
-            let _ = std::fs::remove_file(&pid_path);
-            let _ = std::fs::remove_file(&sock_path);
+            cleanup_daemon_files();
             return Ok(());
         }
     }
@@ -264,8 +319,7 @@ fn stop() -> Result<()> {
     unsafe {
         libc::kill(pid as i32, libc::SIGKILL);
     }
-    let _ = std::fs::remove_file(&pid_path);
-    let _ = std::fs::remove_file(&sock_path);
+    cleanup_daemon_files();
     println!("panda daemon killed");
     Ok(())
 }

--- a/ccr/src/cmd/mod.rs
+++ b/ccr/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod compress;
+pub mod daemon;
 pub mod discover;
 pub mod mcp;
 pub mod doctor;

--- a/ccr/src/main.rs
+++ b/ccr/src/main.rs
@@ -88,6 +88,11 @@ enum Commands {
         #[arg(long)]
         share: bool,
     },
+    /// Manage the embedding daemon (holds BERT model resident for fast inference)
+    Daemon {
+        #[command(subcommand)]
+        action: cmd::daemon::DaemonAction,
+    },
     /// Diagnose CCR installation: hook scripts, settings, analytics DB
     Doctor,
     /// PostToolUse hook mode for Claude Code (hidden)
@@ -205,6 +210,10 @@ fn main() {
     // Apply config-driven model selection and extra keep patterns before any BERT use.
     // set_model_name is no-op after first call, so this must run before any summarization.
     if let Ok(config) = config_loader::load_config() {
+        #[cfg(unix)]
+        if config.global.nice_level > 0 {
+            unsafe { libc::nice(config.global.nice_level); }
+        }
         panda_core::summarizer::set_model_name(&config.global.bert_model);
         panda_core::summarizer::set_extra_keep_patterns(config.global.hard_keep_patterns.clone());
     }
@@ -216,6 +225,7 @@ fn main() {
         }
         Commands::Filter { command } => cmd::filter::run(command),
         Commands::Gain { history, days, breakdown, insight, share } => cmd::gain::run(history, days, breakdown, insight, share),
+        Commands::Daemon { action } => cmd::daemon::run(action),
         Commands::Doctor => cmd::doctor::run(),
         Commands::Hook { subcommand: Some(ref sub) } => hook::run_lifecycle(sub),
         Commands::Hook { subcommand: None } => hook::run(),

--- a/ccr/src/main.rs
+++ b/ccr/src/main.rs
@@ -210,11 +210,8 @@ fn main() {
     // Apply config-driven model selection and extra keep patterns before any BERT use.
     // set_model_name is no-op after first call, so this must run before any summarization.
     if let Ok(config) = config_loader::load_config() {
-        #[cfg(unix)]
-        if config.global.nice_level > 0 {
-            unsafe { libc::nice(config.global.nice_level); }
-        }
         panda_core::summarizer::set_model_name(&config.global.bert_model);
+        panda_core::summarizer::set_nice_level(config.global.nice_level);
         panda_core::summarizer::set_extra_keep_patterns(config.global.hard_keep_patterns.clone());
     }
 


### PR DESCRIPTION
- **socket_path() cached**: `OnceLock` + `libc::getuid()` replaces spawning `id -u` subprocess on every call
- **process_alive EPERM**: correctly treats EPERM as "process exists" instead of "not alive"
- **normalize field honored**: daemon now reads and respects the `normalize` protocol field
- **TOCTOU auto-start**: `try_auto_start()` calls `daemon start` unconditionally (it's idempotent) instead of racy PID file check
- **Cleanup helper**: extracted `cleanup_daemon_files()` to DRY three duplicate cleanup sites
- **`#[cfg(unix)]` guard**: on `embed_client` module for cross-platform correctness
- **C-string literal**: `c"/dev/null"` for type safety (Rust 1.77+)
- **Removed unnecessary `Clone`** derive from `DaemonAction`

## Test plan

- [x] `cargo test` — all 1173 tests pass
- [x] `cargo build` — compiles clean (no new warnings)
- [x] `panda daemon start/stop/status` — lifecycle works correctly
- [x] `time panda filter` with 500 lines — **113ms** (no 5s re-entry delay)
- [x] `ls -la` socket — shows `srwx------` (owner-only)
- [x] `ps -o ni` daemon process — shows nice 10
- [x] Installed locally via `cargo install --path ccr` and tested end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)