### PR TITLE
feat(npu): restore NPU acceleration on upstream ORT via raw OpenVINO bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,53 @@ rm -rf ~/.cache/huggingface/hub/models--sentence-transformers--all-MiniLM-L6-v2
 
 ---
 
+## NPU support (opt-in, Intel only)
+
+Panda's embedding model can run on an Intel NPU (e.g. Meteor Lake NPU 3720)
+through ONNX Runtime's OpenVINO execution provider. This is opt-in.
+
+### Build
+
+```bash
+cargo build --release --features openvino
+```
+
+Requires the OpenVINO 2024+ runtime — specifically `libopenvino_c.so` —
+discoverable at runtime (typically via `LD_LIBRARY_PATH` or a system package).
+`ort` itself ships the ONNX Runtime binary; only the OpenVINO runtime is your
+responsibility.
+
+### Configure
+
+In `panda.toml` (project or `~/.config/panda/config.toml`):
+
+```toml
+[global]
+execution_provider = "npu"   # "auto" | "cpu" | "npu"
+```
+
+Or override at runtime:
+
+```bash
+PANDA_NPU=npu panda daemon start    # force NPU for this daemon
+PANDA_NPU=cpu panda run cargo build # force CPU for this invocation
+```
+
+### How it works
+
+The first call to the embedder pays a one-time OpenVINO compile cost
+(~3–10 s on NPU 3720), cached on disk by OpenVINO under `~/.cache/OpenVINO/`.
+Run `panda daemon start` once at the beginning of a session and every
+subsequent embedding is sub-millisecond dispatch overhead from the warm
+session.
+
+If the OpenVINO EP fails to build a session (driver missing, NPU busy,
+unsupported op), panda silently falls back to CPU and logs one line on
+stderr. To make these failures fatal — useful when diagnosing whether the
+NPU is actually being used — set `PANDA_NPU_STRICT=1`.
+
+---
+
 ## FAQ
 
 **Does PandaFilter change what the agent can see?**

--- a/README.md
+++ b/README.md
@@ -490,7 +490,8 @@ rm -rf ~/.cache/huggingface/hub/models--sentence-transformers--all-MiniLM-L6-v2
 ## NPU support (opt-in, Intel only)
 
 Panda's embedding model can run on an Intel NPU (e.g. Meteor Lake NPU 3720)
-through ONNX Runtime's OpenVINO execution provider. This is opt-in.
+through a direct OpenVINO C-API embedder that bypasses ONNX Runtime entirely.
+This is opt-in.
 
 ### Build
 
@@ -498,10 +499,17 @@ through ONNX Runtime's OpenVINO execution provider. This is opt-in.
 cargo build --release --features openvino
 ```
 
-Requires the OpenVINO 2024+ runtime — specifically `libopenvino_c.so` —
-discoverable at runtime (typically via `LD_LIBRARY_PATH` or a system package).
-`ort` itself ships the ONNX Runtime binary; only the OpenVINO runtime is your
-responsibility.
+The build links against `openvino`/`openvino-sys` (intel/openvino-rs) with
+`runtime-linking`, so no OpenVINO library is required at link time. At
+runtime, panda dlopens `libopenvino_c.so` from the first of:
+
+1. `$OPENVINO_LIB_PATH` (if set; can be a file path or a directory).
+2. `~/.local/share/ccr/onnxruntime/libopenvino_c.so`.
+3. `/usr/lib/x86_64-linux-gnu/libopenvino_c.so`, `/usr/local/lib/...`,
+   `/opt/intel/openvino/runtime/lib/intel64/...`.
+
+Install OpenVINO 2024+ runtime via your distro's package manager or Intel's
+installer.
 
 ### Configure
 
@@ -521,16 +529,18 @@ PANDA_NPU=cpu panda run cargo build # force CPU for this invocation
 
 ### How it works
 
-The first call to the embedder pays a one-time OpenVINO compile cost
-(~3–10 s on NPU 3720), cached on disk by OpenVINO under `~/.cache/OpenVINO/`.
-Run `panda daemon start` once at the beginning of a session and every
-subsequent embedding is sub-millisecond dispatch overhead from the warm
-session.
+The first call pays a one-time NPU compile cost (~3–10 s on NPU 3720). The
+compiled blob is persisted to `~/.cache/panda/openvino/` — subsequent starts
+warm up in <500 ms. Run `panda daemon start` once at the beginning of a
+session and every embedding is sub-millisecond dispatch overhead from the
+warm InferRequest pool (size matches the NPU's reported optimal request
+count, typically 4 on Meteor Lake's two-tile NPU 3720).
 
-If the OpenVINO EP fails to build a session (driver missing, NPU busy,
-unsupported op), panda silently falls back to CPU and logs one line on
-stderr. To make these failures fatal — useful when diagnosing whether the
-NPU is actually being used — set `PANDA_NPU_STRICT=1`.
+If NPU initialisation or inference fails, panda logs one line on stderr and
+falls back to CPU for the rest of the process — the daemon doesn't crash.
+To make these failures fatal (useful when diagnosing whether NPU is actually
+in use), set `PANDA_NPU_STRICT=1`. To force a specific inference precision,
+set `PANDA_NPU_PRECISION=FP16` or `=FP32`.
 
 ---
 

--- a/ccr-core/Cargo.toml
+++ b/ccr-core/Cargo.toml
@@ -20,5 +20,9 @@ hf-hub = { version = "0.4", features = ["ureq", "native-tls"] }
 rusqlite = { version = "0.31", features = ["bundled"] }
 walkdir = "2"
 
+[features]
+default = []
+openvino = ["ort/openvino"]
+
 [dev-dependencies]
 tempfile = "3"

--- a/ccr-core/Cargo.toml
+++ b/ccr-core/Cargo.toml
@@ -19,10 +19,12 @@ ndarray = "0.17"
 hf-hub = { version = "0.4", features = ["ureq", "native-tls"] }
 rusqlite = { version = "0.31", features = ["bundled"] }
 walkdir = "2"
+openvino = { git = "https://github.com/intel/openvino-rs", rev = "e25f1f848edc", features = ["runtime-linking"], optional = true }
+openvino-sys = { git = "https://github.com/intel/openvino-rs", rev = "e25f1f848edc", features = ["runtime-linking"], optional = true }
 
 [features]
 default = []
-openvino = ["ort/openvino"]
+openvino = ["dep:openvino", "dep:openvino-sys"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/ccr-core/src/config.rs
+++ b/ccr-core/src/config.rs
@@ -109,6 +109,11 @@ pub struct GlobalConfig {
     /// Higher values speed up large batches but compete with the editor/LSP.
     #[serde(default = "default_ort_threads")]
     pub ort_threads: usize,
+    /// Which ONNX Runtime execution provider to use for embeddings.
+    /// Values: "auto" (NPU if compiled with --features openvino, else CPU),
+    /// "cpu", "npu". Override at runtime with PANDA_NPU=cpu|npu.
+    #[serde(default = "default_execution_provider")]
+    pub execution_provider: String,
 }
 
 fn default_input_char_ceiling() -> usize {
@@ -129,6 +134,10 @@ fn default_nice_level() -> i32 {
 
 fn default_ort_threads() -> usize {
     2
+}
+
+fn default_execution_provider() -> String {
+    "auto".to_string()
 }
 
 fn default_state_commands() -> Vec<String> {
@@ -157,6 +166,7 @@ impl Default for GlobalConfig {
             router_exploration_noise: false,
             nice_level: default_nice_level(),
             ort_threads: default_ort_threads(),
+            execution_provider: default_execution_provider(),
         }
     }
 }
@@ -262,4 +272,24 @@ pub struct MatchOutputConfig {
 pub enum SimpleAction {
     Remove,
     Collapse,
+}
+
+#[cfg(test)]
+mod execution_provider_tests {
+    use super::*;
+
+    #[test]
+    fn execution_provider_defaults_to_auto() {
+        let cfg: CcrConfig = toml::from_str("").unwrap();
+        assert_eq!(cfg.global.execution_provider, "auto");
+    }
+
+    #[test]
+    fn execution_provider_round_trips() {
+        let cfg: CcrConfig = toml::from_str(
+            "[global]\nexecution_provider = \"npu\"\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.global.execution_provider, "npu");
+    }
 }

--- a/ccr-core/src/lib.rs
+++ b/ccr-core/src/lib.rs
@@ -9,6 +9,8 @@ pub mod focus;
 pub mod jsonlog;
 pub mod ndjson;
 pub mod patterns;
+#[cfg(feature = "openvino")]
+pub(crate) mod ov_embed;
 pub mod pipeline;
 pub mod router;
 pub mod sentence;

--- a/ccr-core/src/ov_embed.rs
+++ b/ccr-core/src/ov_embed.rs
@@ -1,0 +1,352 @@
+use anyhow::{Context, Result};
+use openvino::{
+    Core, DeviceType, ElementType, PartialShape, PropertyKey, RwPropertyKey, Shape, Tensor,
+};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::thread;
+use tokenizers::Tokenizer;
+
+// Process-wide flag: once an OvEmbedder call hits a hard NPU error after a
+// retry, this flips to true and `is_degraded()` makes summarizer.rs skip the
+// NPU path for the rest of the process. Reset only by restarting panda.
+static DEGRADED: AtomicBool = AtomicBool::new(false);
+
+pub fn is_degraded() -> bool {
+    DEGRADED.load(Ordering::Relaxed)
+}
+
+fn mark_degraded(reason: &str) {
+    if !DEGRADED.swap(true, Ordering::Relaxed) {
+        eprintln!("[panda] NPU embedder failed ({reason}); falling back to CPU");
+    }
+}
+
+// openvino-sys loads `libopenvino_c.so` (the C API shim), not `libopenvino.so`.
+const OV_C_LIB_CANDIDATES: &[&str] = &[
+    "/usr/lib/x86_64-linux-gnu/libopenvino_c.so",
+    "/usr/local/lib/libopenvino_c.so",
+    "/opt/intel/openvino/runtime/lib/intel64/libopenvino_c.so",
+];
+
+pub fn ov_lib_path() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("OPENVINO_LIB_PATH") {
+        let pb = PathBuf::from(&p);
+        let candidate = if pb.is_dir() {
+            pb.join("libopenvino_c.so")
+        } else {
+            pb
+        };
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    let ccr_path = std::env::var("HOME").ok().map(|h| {
+        PathBuf::from(h).join(".local/share/ccr/onnxruntime/libopenvino_c.so")
+    });
+    if let Some(p) = ccr_path {
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    for cand in OV_C_LIB_CANDIDATES {
+        let p = PathBuf::from(cand);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Per-model NPU sequence length. Returns `None` for unknown models — caller
+/// should fall through to the CPU embedder.
+///
+/// Mirrors the model registry in `summarizer::model_registry`. When new
+/// models are added there, add their NPU `seq_len` here.
+pub fn model_seq_len(model_name: &str) -> Option<usize> {
+    match model_name {
+        "AllMiniLML6V2" => Some(128),
+        "AllMiniLML12V2" => Some(128),
+        _ => None,
+    }
+}
+
+pub struct OvEmbedder {
+    _core: Core,
+    // Compiled model is kept alive but the InferRequests are pre-allocated up
+    // front; we never call create_infer_request again at runtime.
+    _compiled: openvino::CompiledModel,
+    // Pool of pre-allocated requests. Drained on each embed() call, refilled
+    // with the same requests after parallel work completes. Size matches the
+    // NPU's reported OPTIMAL_NUMBER_OF_INFER_REQUESTS (typically 4 on Meteor
+    // Lake's 2-tile NPU 3720).
+    requests: Mutex<Vec<openvino::InferRequest>>,
+    tokenizer: Tokenizer,
+    seq_len: usize,
+    hidden_size: usize,
+    has_token_type: bool,
+}
+
+// SAFETY: openvino-rs marks both CompiledModel (Send) and InferRequest
+// (Send + Sync) safe; the Mutex around the request pool guards refill semantics.
+unsafe impl Send for OvEmbedder {}
+unsafe impl Sync for OvEmbedder {}
+
+impl OvEmbedder {
+    pub fn try_new(onnx_path: &Path, tokenizer_path: &Path, seq_len: usize) -> Result<Self> {
+        let lib = ov_lib_path()
+            .context("libopenvino.so not found; install OpenVINO or set OPENVINO_LIB_PATH")?;
+        openvino_sys::library::load_from(&lib)
+            .map_err(|e| anyhow::anyhow!("OpenVINO load failed: {e}"))?;
+
+        let mut core = Core::new().context("OpenVINO Core::new() failed")?;
+
+        // Persist compiled-model blob between process invocations. NPU
+        // compile is multi-second; cache turns subsequent starts into <500 ms.
+        // The plugin invalidates the cache automatically on driver/OV upgrade.
+        let cache_dir = std::env::var("HOME")
+            .map(|h| PathBuf::from(h).join(".cache/panda/openvino"))
+            .unwrap_or_else(|_| PathBuf::from(".panda-openvino-cache"));
+        if let Err(e) = std::fs::create_dir_all(&cache_dir) {
+            eprintln!(
+                "[panda] could not create NPU cache dir {}: {} (continuing without cache)",
+                cache_dir.display(),
+                e
+            );
+        } else if let Some(s) = cache_dir.to_str() {
+            if let Err(e) = core.set_property(&DeviceType::NPU, &RwPropertyKey::CacheDir, s) {
+                eprintln!("[panda] could not enable NPU model cache: {e:?}");
+            }
+        }
+
+        // PERFORMANCE_HINT=THROUGHPUT tells the NPU plugin to optimise for
+        // multiple in-flight infer requests rather than single-call latency.
+        // Without this hint, OPTIMAL_NUMBER_OF_INFER_REQUESTS often reports 1
+        // and the device sits idle between sync calls.
+        if let Err(e) =
+            core.set_property(&DeviceType::NPU, &RwPropertyKey::HintPerformanceMode, "THROUGHPUT")
+        {
+            eprintln!("[panda] could not set NPU PERFORMANCE_HINT: {e:?}");
+        }
+
+        // INFERENCE_PRECISION_HINT can be used to force FP16/FP32, but the
+        // NPU 3720 plugin already runs in FP16 by default — setting the hint
+        // explicitly regressed throughput and broke the cache during testing.
+        // Allow advanced users to override via PANDA_NPU_PRECISION but leave
+        // the plugin default in place when the env var is unset.
+        if let Ok(precision) = std::env::var("PANDA_NPU_PRECISION") {
+            let precision = precision.trim();
+            if !precision.is_empty() {
+                if let Err(e) = core.set_property(
+                    &DeviceType::NPU,
+                    &RwPropertyKey::HintInferencePrecision,
+                    precision,
+                ) {
+                    eprintln!(
+                        "[panda] could not set NPU INFERENCE_PRECISION_HINT={precision}: {e:?}"
+                    );
+                }
+            }
+        }
+
+        let mut model = core
+            .read_model_from_file(onnx_path.to_str().unwrap(), "")
+            .context("Failed to read ONNX model into OpenVINO")?;
+
+        // NPU plugin requires static shapes. Batch=1 + parallel async requests
+        // is the canonical NPU recipe; batched models on NPU regress.
+        let n_inputs = model.get_inputs_len()?;
+        let static_shape = PartialShape::new_static(2, &[1, seq_len as i64])?;
+        for i in 0..n_inputs {
+            let name = model.get_input_by_index(i)?.get_name()?;
+            model.reshape_input_by_name(&name, &static_shape)?;
+        }
+
+        eprint!("[panda] compiling model for NPU (one-time per session)...");
+        let mut compiled = core
+            .compile_model(&model, DeviceType::NPU)
+            .context("NPU compile_model failed")?;
+        eprintln!(" done");
+
+        let out_node = compiled.get_output_by_index(0)?;
+        let shape = out_node.get_shape()?;
+        let dims = shape.get_dimensions();
+        let hidden_size = dims.last().copied().unwrap_or(384) as usize;
+
+        let has_token_type = compiled.get_input_size()? > 2;
+
+        // Query the optimal in-flight infer-request count. The NPU plugin
+        // returns 4 on Meteor Lake; clamp to [1, 8] as a sanity bound.
+        let pool_size = compiled
+            .get_property(&PropertyKey::OptimalNumberOfInferRequests)
+            .ok()
+            .and_then(|s| s.trim().parse::<usize>().ok())
+            .unwrap_or(4)
+            .clamp(1, 8);
+
+        let mut requests = Vec::with_capacity(pool_size);
+        for _ in 0..pool_size {
+            requests.push(
+                compiled
+                    .create_infer_request()
+                    .context("create_infer_request failed")?,
+            );
+        }
+        eprintln!("[panda] NPU infer-request pool size: {}", pool_size);
+
+        let tokenizer = Tokenizer::from_file(tokenizer_path)
+            .map_err(|e| anyhow::anyhow!("tokenizer load: {e}"))?;
+
+        Ok(OvEmbedder {
+            _core: core,
+            _compiled: compiled,
+            requests: Mutex::new(requests),
+            tokenizer,
+            seq_len,
+            hidden_size,
+            has_token_type,
+        })
+    }
+
+    /// Embed texts and return L2-normalised vectors (one per input).
+    /// Runs the request pool in parallel — N worker threads, each holding one
+    /// dedicated InferRequest, processing texts via an atomic work counter.
+    pub fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Drain the request pool. Threads will return their request at the
+        // end; we refill the pool before returning.
+        let owned_reqs: Vec<openvino::InferRequest> = {
+            let mut guard = self.requests.lock().unwrap();
+            std::mem::take(&mut *guard)
+        };
+        if owned_reqs.is_empty() {
+            return Err(anyhow::anyhow!("NPU request pool empty"));
+        }
+
+        let next = AtomicUsize::new(0);
+        let local_degraded = AtomicBool::new(false);
+        let outputs: Vec<Mutex<Option<Vec<f32>>>> =
+            (0..texts.len()).map(|_| Mutex::new(None)).collect();
+
+        let returned = thread::scope(|s| -> Vec<openvino::InferRequest> {
+            let handles: Vec<_> = owned_reqs
+                .into_iter()
+                .map(|mut req| {
+                    let next_ref = &next;
+                    let degraded_ref = &local_degraded;
+                    let outputs_ref = &outputs;
+                    s.spawn(move || -> openvino::InferRequest {
+                        loop {
+                            if degraded_ref.load(Ordering::Relaxed) {
+                                break;
+                            }
+                            let idx = next_ref.fetch_add(1, Ordering::Relaxed);
+                            if idx >= texts.len() {
+                                break;
+                            }
+                            let result = match self.embed_one_with(&mut req, texts[idx]) {
+                                Ok(v) => Some(v),
+                                Err(_) => self.embed_one_with(&mut req, texts[idx]).ok(),
+                            };
+                            match result {
+                                Some(v) => *outputs_ref[idx].lock().unwrap() = Some(v),
+                                None => {
+                                    degraded_ref.store(true, Ordering::Relaxed);
+                                    break;
+                                }
+                            }
+                        }
+                        req
+                    })
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        // Refill the pool whether we succeeded or not — the requests are still
+        // valid even after a single failed infer.
+        *self.requests.lock().unwrap() = returned;
+
+        if local_degraded.load(Ordering::Relaxed) {
+            mark_degraded("infer error after retry");
+            return Err(anyhow::anyhow!("NPU embed failed; using CPU"));
+        }
+
+        let mut out = Vec::with_capacity(texts.len());
+        for slot in outputs {
+            match slot.into_inner().unwrap() {
+                Some(v) => out.push(v),
+                None => return Err(anyhow::anyhow!("NPU embed produced no output for index")),
+            }
+        }
+        Ok(out)
+    }
+
+    /// Run one tokenise → infer → mean-pool → normalise pipeline against the
+    /// supplied dedicated request. Used by the worker loop.
+    fn embed_one_with(
+        &self,
+        req: &mut openvino::InferRequest,
+        text: &str,
+    ) -> Result<Vec<f32>> {
+        let enc = self
+            .tokenizer
+            .encode(text, true)
+            .map_err(|e| anyhow::anyhow!("tokenize: {e}"))?;
+
+        let ids = enc.get_ids();
+        let mask = enc.get_attention_mask();
+        let actual_len = ids.len().min(self.seq_len);
+
+        let mut id_data = vec![0i64; self.seq_len];
+        let mut mask_data = vec![0i64; self.seq_len];
+        for k in 0..actual_len {
+            id_data[k] = ids[k] as i64;
+            mask_data[k] = mask[k] as i64;
+        }
+
+        let shape = Shape::new(&[1, self.seq_len as i64])?;
+        let mut id_tensor = Tensor::new(ElementType::I64, &shape)?;
+        id_tensor.get_data_mut::<i64>()?.copy_from_slice(&id_data);
+        let mut mask_tensor = Tensor::new(ElementType::I64, &shape)?;
+        mask_tensor.get_data_mut::<i64>()?.copy_from_slice(&mask_data);
+
+        req.set_tensor("input_ids", &id_tensor)?;
+        req.set_tensor("attention_mask", &mask_tensor)?;
+        if self.has_token_type {
+            let tt_tensor = Tensor::new(ElementType::I64, &shape)?;
+            let _ = req.set_tensor("token_type_ids", &tt_tensor);
+        }
+
+        req.infer()?;
+
+        let out = req.get_output_tensor_by_index(0)?;
+        let data: &[f32] = out.get_data::<f32>()?;
+
+        let mut pooled = vec![0.0f32; self.hidden_size];
+        let mut count = 0usize;
+        for token_idx in 0..actual_len {
+            if mask_data[token_idx] == 0 {
+                continue;
+            }
+            let offset = token_idx * self.hidden_size;
+            for (j, v) in data[offset..offset + self.hidden_size].iter().enumerate() {
+                pooled[j] += v;
+            }
+            count += 1;
+        }
+        if count > 0 {
+            let n = count as f32;
+            pooled.iter_mut().for_each(|v| *v /= n);
+        }
+        let norm: f32 = pooled.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 1e-9 {
+            pooled.iter_mut().for_each(|v| *v /= norm);
+        }
+        Ok(pooled)
+    }
+}

--- a/ccr-core/src/ov_embed.rs
+++ b/ccr-core/src/ov_embed.rs
@@ -350,3 +350,78 @@ impl OvEmbedder {
         Ok(pooled)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // env tests share process state — serialize them.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear_env() {
+        std::env::remove_var("OPENVINO_LIB_PATH");
+    }
+
+    #[test]
+    fn ov_lib_path_returns_none_when_nothing_present() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_env();
+        let tmp = tempfile::tempdir().unwrap();
+        let saved_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", tmp.path());
+        let result = ov_lib_path();
+        if let Some(home) = saved_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        // Result depends on whether /usr/lib/... has libopenvino_c.so on the
+        // host. If yes, that's also valid — just assert no panic.
+        let _ = result;
+    }
+
+    #[test]
+    fn ov_lib_path_honours_env_file() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("libopenvino_c.so");
+        std::fs::write(&path, b"stub").unwrap();
+        std::env::set_var("OPENVINO_LIB_PATH", &path);
+        let resolved = ov_lib_path();
+        std::env::remove_var("OPENVINO_LIB_PATH");
+        assert_eq!(resolved.as_deref(), Some(path.as_path()));
+    }
+
+    #[test]
+    fn ov_lib_path_honours_env_dir() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = tmp.path().join("libopenvino_c.so");
+        std::fs::write(&lib, b"stub").unwrap();
+        std::env::set_var("OPENVINO_LIB_PATH", tmp.path());
+        let resolved = ov_lib_path();
+        std::env::remove_var("OPENVINO_LIB_PATH");
+        assert_eq!(resolved.as_deref(), Some(lib.as_path()));
+    }
+
+    #[test]
+    fn model_seq_len_returns_known_models() {
+        assert_eq!(model_seq_len("AllMiniLML6V2"), Some(128));
+        assert_eq!(model_seq_len("AllMiniLML12V2"), Some(128));
+        assert_eq!(model_seq_len("nonsense"), None);
+        assert_eq!(model_seq_len(""), None);
+    }
+
+    #[test]
+    fn is_degraded_starts_false_marks_true_idempotent() {
+        // Note: DEGRADED is a process-wide flag. This test must run before
+        // any other test in this file would call mark_degraded — currently
+        // none do, so we're safe. Ordering caveat noted.
+        assert!(!is_degraded(), "DEGRADED should start clear");
+        mark_degraded("test-1");
+        assert!(is_degraded(), "DEGRADED should be set after first call");
+        mark_degraded("test-2"); // Should not panic, should not double-print
+        assert!(is_degraded());
+    }
+}

--- a/ccr-core/src/summarizer.rs
+++ b/ccr-core/src/summarizer.rs
@@ -425,11 +425,19 @@ fn get_ov_embedder() -> Option<&'static crate::ov_embed::OvEmbedder> {
 /// multi-second NPU compile happens once at start, not on the first client
 /// embed call.
 ///
-/// Returns `Some(())` on success, `None` if construction failed (in which
-/// case `OV_EMBEDDER` is cached as `None` and subsequent calls go to CPU).
+/// Returns `Ok(())` on success, `Err` when init failed and `PANDA_NPU_STRICT=1`
+/// is set (so the caller can fail loud). When strict mode is off, init failure
+/// is reported as `Ok(())` because `OV_EMBEDDER` caches `None` and subsequent
+/// calls degrade to CPU automatically.
 #[cfg(feature = "openvino")]
-pub fn preload_ov_embedder() -> Option<()> {
-    get_ov_embedder().map(|_| ())
+pub fn preload_ov_embedder() -> anyhow::Result<()> {
+    if get_ov_embedder().is_some() {
+        return Ok(());
+    }
+    if std::env::var("PANDA_NPU_STRICT").ok().as_deref() == Some("1") {
+        anyhow::bail!("PANDA_NPU_STRICT=1: OpenVINO NPU embedder failed to initialize");
+    }
+    Ok(())
 }
 
 /// Reports whether the OV embedder is currently active. Used by the smoke

--- a/ccr-core/src/summarizer.rs
+++ b/ccr-core/src/summarizer.rs
@@ -375,6 +375,69 @@ pub fn preload_model() -> anyhow::Result<()> {
     Ok(())
 }
 
+// ── Raw OpenVINO bypass (opt-in via --features openvino) ─────────────────────
+
+#[cfg(feature = "openvino")]
+static OV_EMBEDDER: OnceCell<Option<crate::ov_embed::OvEmbedder>> = OnceCell::new();
+
+/// Lazily construct the OV embedder. Returns `None` (cached) on any failure
+/// or once `is_degraded()` flips. Idempotent and process-lifetime stable.
+#[cfg(feature = "openvino")]
+fn get_ov_embedder() -> Option<&'static crate::ov_embed::OvEmbedder> {
+    if crate::ov_embed::is_degraded() {
+        return None;
+    }
+    OV_EMBEDDER
+        .get_or_init(|| {
+            let name = get_model_name();
+            let (onnx, tok) = match resolve_model_files(name) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("[panda] OV bypass: model fetch failed: {e}");
+                    return None;
+                }
+            };
+            let seq_len = match crate::ov_embed::model_seq_len(name) {
+                Some(s) => s,
+                None => {
+                    eprintln!(
+                        "[panda] OV bypass: no NPU seq_len for {name}; CPU fallback"
+                    );
+                    return None;
+                }
+            };
+            match crate::ov_embed::OvEmbedder::try_new(&onnx, &tok, seq_len) {
+                Ok(e) => {
+                    eprintln!("[panda] embedder: {} on NPU (raw OpenVINO)", name);
+                    Some(e)
+                }
+                Err(err) => {
+                    eprintln!("[panda] OV bypass init failed: {err}");
+                    None
+                }
+            }
+        })
+        .as_ref()
+}
+
+/// Eagerly construct the OV embedder. Used by `panda daemon start` so the
+/// multi-second NPU compile happens once at start, not on the first client
+/// embed call.
+///
+/// Returns `Some(())` on success, `None` if construction failed (in which
+/// case `OV_EMBEDDER` is cached as `None` and subsequent calls go to CPU).
+#[cfg(feature = "openvino")]
+pub fn preload_ov_embedder() -> Option<()> {
+    get_ov_embedder().map(|_| ())
+}
+
+/// Reports whether the OV embedder is currently active. Used by the smoke
+/// test to assert NPU was actually engaged (vs silent CPU fallback).
+#[cfg(feature = "openvino")]
+pub fn ov_embedder_is_active() -> bool {
+    OV_EMBEDDER.get().and_then(|o| o.as_ref()).is_some()
+}
+
 // ── Math helpers ──────────────────────────────────────────────────────────────
 
 /// L2-normalize `v` in-place. No-op for zero vectors.

--- a/ccr-core/src/summarizer.rs
+++ b/ccr-core/src/summarizer.rs
@@ -214,62 +214,16 @@ impl MiniLmEmbedder {
 
         let threads = ORT_THREADS.get().copied().unwrap_or(2).max(1);
 
-        // Build the EP list. CPU is always last so ORT can per-op fall through
-        // when the accelerator EP can't compile a node.
-        let strict = std::env::var("PANDA_NPU_STRICT").ok().as_deref() == Some("1");
-        let chosen_ep = current_ep();
-
-        let build_session = |use_npu: bool| -> anyhow::Result<ort::session::Session> {
-            let mut b = ort::session::Session::builder().map_err(ort_err)?;
-            b = b
-                .with_optimization_level(ort::session::builder::GraphOptimizationLevel::Level3)
-                .map_err(ort_err)?;
-            b = b.with_memory_pattern(false).map_err(ort_err)?;
-            b = b.with_intra_threads(threads).map_err(ort_err)?;
-
-            let mut eps: Vec<ort::ep::ExecutionProviderDispatch> = Vec::new();
-            #[cfg(feature = "openvino")]
-            if use_npu {
-                eps.push(
-                    ort::ep::OpenVINO::default()
-                        .with_device_type("NPU")
-                        .build()
-                        .into(),
-                );
-            }
-            // Suppress the "unused" warning when the openvino feature is off.
-            let _ = use_npu;
-            eps.push(
-                ort::ep::CPU::default()
-                    .with_arena_allocator(false)
-                    .build()
-                    .into(),
-            );
-
-            b = b.with_execution_providers(eps).map_err(ort_err)?;
-            b.commit_from_file(&model_path).map_err(ort_err)
-        };
-
-        let want_npu = chosen_ep == "npu";
-        let session = match build_session(want_npu) {
-            Ok(s) => {
-                eprintln!(
-                    "[panda] embedder: {} on {}",
-                    name,
-                    if want_npu { "NPU" } else { "CPU" }
-                );
-                s
-            }
-            Err(e) if want_npu && !strict => {
-                eprintln!(
-                    "[panda] OpenVINO EP unavailable: {e}; falling back to CPU"
-                );
-                let s = build_session(false)?;
-                eprintln!("[panda] embedder: {} on CPU (fallback)", name);
-                s
-            }
-            Err(e) => return Err(e),
-        };
+        let mut builder = ort::session::Session::builder().map_err(ort_err)?;
+        builder = builder
+            .with_optimization_level(ort::session::builder::GraphOptimizationLevel::Level3)
+            .map_err(ort_err)?;
+        builder = builder.with_memory_pattern(false).map_err(ort_err)?;
+        builder = builder.with_intra_threads(threads).map_err(ort_err)?;
+        builder = builder
+            .with_execution_providers([ort::ep::CPU::default().with_arena_allocator(false).build()])
+            .map_err(ort_err)?;
+        let session = builder.commit_from_file(&model_path).map_err(ort_err)?;
 
         let need_token_type_ids = session
             .inputs()

--- a/ccr-core/src/summarizer.rs
+++ b/ccr-core/src/summarizer.rs
@@ -114,7 +114,7 @@ pub(crate) fn ep_choice(configured: &str) -> &'static str {
 }
 
 /// Convenience: read the configured EP from the static and resolve it.
-pub(crate) fn current_ep() -> &'static str {
+pub fn current_ep() -> &'static str {
     let configured = EXECUTION_PROVIDER
         .get()
         .map(|s| s.as_str())
@@ -366,6 +366,7 @@ fn get_model() -> anyhow::Result<&'static MiniLmEmbedder> {
         }
         let embedder = MiniLmEmbedder::new(name)?;
         mark_bert_cached(name);
+        eprintln!("[panda] embedder: {} on CPU (ort)", name);
         Ok(embedder)
     })
 }
@@ -497,6 +498,17 @@ fn compute_centroid(embeddings: &[Vec<f32>]) -> Vec<f32> {
 }
 
 pub fn embed_direct(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
+    #[cfg(feature = "openvino")]
+    if current_ep() == "npu" {
+        if let Some(ov) = get_ov_embedder() {
+            let texts_slice: Vec<&str> = texts.iter().copied().collect();
+            let mut v = ov.embed(&texts_slice)?;
+            for e in &mut v {
+                l2_normalize(e);
+            }
+            return Ok(v);
+        }
+    }
     let model = get_model()?;
     let mut embeddings = model.embed(&texts)?;
     for emb in &mut embeddings {
@@ -514,6 +526,17 @@ fn embed_and_normalize(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
     #[cfg(unix)]
     if let Some(embeddings) = crate::embed_client::daemon_embed(&texts, true) {
         return Ok(embeddings);
+    }
+    #[cfg(feature = "openvino")]
+    if current_ep() == "npu" {
+        if let Some(ov) = get_ov_embedder() {
+            let texts_slice: Vec<&str> = texts.iter().copied().collect();
+            let mut v = ov.embed(&texts_slice)?;
+            for e in &mut v {
+                l2_normalize(e);
+            }
+            return Ok(v);
+        }
     }
     #[cfg(unix)]
     apply_nice_once();

--- a/ccr-core/src/summarizer.rs
+++ b/ccr-core/src/summarizer.rs
@@ -64,6 +64,64 @@ pub fn set_ort_threads(n: usize) {
     let _ = ORT_THREADS.set(n);
 }
 
+static EXECUTION_PROVIDER: OnceCell<String> = OnceCell::new();
+
+/// Set the desired ORT execution provider. Values: "auto", "cpu", "npu".
+/// First call wins, mirroring `set_model_name` semantics.
+pub fn set_execution_provider(s: &str) {
+    let _ = EXECUTION_PROVIDER.set(s.to_string());
+}
+
+/// Resolve the configured execution provider into a concrete EP name.
+///
+/// Resolution order:
+///   1. If `PANDA_NPU` env var is set, it wins.
+///   2. Otherwise the `configured` argument (typically read from
+///      `EXECUTION_PROVIDER.get()`) is used.
+///   3. "auto" / unknown values resolve to "npu" if the openvino feature
+///      is compiled in, else "cpu".
+///
+/// Always returns either "cpu" or "npu" — never "auto".
+pub(crate) fn ep_choice(configured: &str) -> &'static str {
+    let raw = std::env::var("PANDA_NPU")
+        .ok()
+        .unwrap_or_else(|| configured.to_string());
+    match raw.as_str() {
+        "cpu" => "cpu",
+        "npu" => {
+            #[cfg(feature = "openvino")]
+            { "npu" }
+            #[cfg(not(feature = "openvino"))]
+            {
+                static WARNED: std::sync::Once = std::sync::Once::new();
+                WARNED.call_once(|| {
+                    eprintln!(
+                        "[panda] execution_provider=npu but binary built without \
+                         openvino feature; using CPU"
+                    );
+                });
+                "cpu"
+            }
+        }
+        _ => {
+            // "auto" or unknown — resolve based on compiled feature set.
+            #[cfg(feature = "openvino")]
+            { "npu" }
+            #[cfg(not(feature = "openvino"))]
+            { "cpu" }
+        }
+    }
+}
+
+/// Convenience: read the configured EP from the static and resolve it.
+pub(crate) fn current_ep() -> &'static str {
+    let configured = EXECUTION_PROVIDER
+        .get()
+        .map(|s| s.as_str())
+        .unwrap_or("auto");
+    ep_choice(configured)
+}
+
 #[cfg(unix)]
 fn apply_nice_once() {
     static APPLIED: std::sync::Once = std::sync::Once::new();
@@ -1849,5 +1907,46 @@ mod tests {
         }
 
         assert_eq!(pooled, vec![0.0, 0.0, 0.0]);
+    }
+}
+
+#[cfg(test)]
+mod ep_resolver_tests {
+    use super::ep_choice;
+
+    fn clear_env() {
+        std::env::remove_var("PANDA_NPU");
+    }
+
+    #[test]
+    fn auto_resolves_to_cpu_without_feature_flag() {
+        // Without `--features openvino`, "auto" must resolve to "cpu".
+        clear_env();
+        let resolved = ep_choice("auto");
+        #[cfg(not(feature = "openvino"))]
+        assert_eq!(resolved, "cpu");
+        #[cfg(feature = "openvino")]
+        assert_eq!(resolved, "npu");
+    }
+
+    #[test]
+    fn explicit_cpu_stays_cpu() {
+        clear_env();
+        assert_eq!(ep_choice("cpu"), "cpu");
+    }
+
+    #[test]
+    fn unknown_value_falls_back_to_cpu_without_panic() {
+        clear_env();
+        // Should not panic. Unknown values resolve like "auto".
+        let resolved = ep_choice("banana");
+        assert!(resolved == "cpu" || resolved == "npu");
+    }
+
+    #[test]
+    fn panda_npu_env_overrides_config() {
+        std::env::set_var("PANDA_NPU", "cpu");
+        assert_eq!(ep_choice("npu"), "cpu");
+        std::env::remove_var("PANDA_NPU");
     }
 }

--- a/ccr-core/src/summarizer.rs
+++ b/ccr-core/src/summarizer.rs
@@ -213,16 +213,63 @@ impl MiniLmEmbedder {
         let tokenizer = load_tokenizer(&tokenizer_path)?;
 
         let threads = ORT_THREADS.get().copied().unwrap_or(2).max(1);
-        let mut builder = ort::session::Session::builder().map_err(ort_err)?;
-        builder = builder
-            .with_optimization_level(ort::session::builder::GraphOptimizationLevel::Level3)
-            .map_err(ort_err)?;
-        builder = builder.with_memory_pattern(false).map_err(ort_err)?;
-        builder = builder.with_intra_threads(threads).map_err(ort_err)?;
-        builder = builder
-            .with_execution_providers([ort::ep::CPU::default().with_arena_allocator(false).build()])
-            .map_err(ort_err)?;
-        let session = builder.commit_from_file(&model_path).map_err(ort_err)?;
+
+        // Build the EP list. CPU is always last so ORT can per-op fall through
+        // when the accelerator EP can't compile a node.
+        let strict = std::env::var("PANDA_NPU_STRICT").ok().as_deref() == Some("1");
+        let chosen_ep = current_ep();
+
+        let build_session = |use_npu: bool| -> anyhow::Result<ort::session::Session> {
+            let mut b = ort::session::Session::builder().map_err(ort_err)?;
+            b = b
+                .with_optimization_level(ort::session::builder::GraphOptimizationLevel::Level3)
+                .map_err(ort_err)?;
+            b = b.with_memory_pattern(false).map_err(ort_err)?;
+            b = b.with_intra_threads(threads).map_err(ort_err)?;
+
+            let mut eps: Vec<ort::ep::ExecutionProviderDispatch> = Vec::new();
+            #[cfg(feature = "openvino")]
+            if use_npu {
+                eps.push(
+                    ort::ep::OpenVINO::default()
+                        .with_device_type("NPU")
+                        .build()
+                        .into(),
+                );
+            }
+            // Suppress the "unused" warning when the openvino feature is off.
+            let _ = use_npu;
+            eps.push(
+                ort::ep::CPU::default()
+                    .with_arena_allocator(false)
+                    .build()
+                    .into(),
+            );
+
+            b = b.with_execution_providers(eps).map_err(ort_err)?;
+            b.commit_from_file(&model_path).map_err(ort_err)
+        };
+
+        let want_npu = chosen_ep == "npu";
+        let session = match build_session(want_npu) {
+            Ok(s) => {
+                eprintln!(
+                    "[panda] embedder: {} on {}",
+                    name,
+                    if want_npu { "NPU" } else { "CPU" }
+                );
+                s
+            }
+            Err(e) if want_npu && !strict => {
+                eprintln!(
+                    "[panda] OpenVINO EP unavailable: {e}; falling back to CPU"
+                );
+                let s = build_session(false)?;
+                eprintln!("[panda] embedder: {} on CPU (fallback)", name);
+                s
+            }
+            Err(e) => return Err(e),
+        };
 
         let need_token_type_ids = session
             .inputs()

--- a/ccr-core/tests/npu_fallback.rs
+++ b/ccr-core/tests/npu_fallback.rs
@@ -1,0 +1,37 @@
+//! Feature-gated CPU-fallback test for the OpenVINO bypass.
+//!
+//! Lives in its own integration-test file so it runs in a separate process
+//! from `npu_smoke.rs`. Both tests touch the `OV_EMBEDDER` `OnceCell`, and
+//! once one of them caches `None` the other can't recover within the same
+//! process.
+
+#![cfg(feature = "openvino")]
+
+use panda_core::summarizer;
+
+fn npu_opted_in() -> bool {
+    std::env::var("OPENVINO_NPU_AVAILABLE").ok().as_deref() == Some("1")
+}
+
+#[test]
+fn npu_falls_back_to_cpu_when_libopenvino_missing() {
+    if !npu_opted_in() {
+        eprintln!("skipping: OPENVINO_NPU_AVAILABLE != 1");
+        return;
+    }
+    // Hide libopenvino_c.so so OvEmbedder::try_new fails. ov_lib_path()
+    // checks OPENVINO_LIB_PATH first, so pointing it at /dev/null beats
+    // any other path on the host.
+    std::env::set_var("OPENVINO_LIB_PATH", "/dev/null");
+    summarizer::set_execution_provider("npu");
+
+    // Embedding should still succeed via CPU fallback.
+    let r = summarizer::embed_direct(vec!["x"]);
+    std::env::remove_var("OPENVINO_LIB_PATH");
+
+    assert!(r.is_ok(), "expected CPU fallback to succeed: {:?}", r.err());
+    assert!(
+        !summarizer::ov_embedder_is_active(),
+        "OV embedder must NOT be active when libopenvino is hidden"
+    );
+}

--- a/ccr-core/tests/npu_smoke.rs
+++ b/ccr-core/tests/npu_smoke.rs
@@ -45,25 +45,3 @@ fn npu_smoke_actually_uses_npu() {
     eprintln!("npu embed elapsed: {elapsed:?}");
 }
 
-#[test]
-fn npu_falls_back_to_cpu_when_libopenvino_missing() {
-    if !npu_opted_in() {
-        eprintln!("skipping: OPENVINO_NPU_AVAILABLE != 1");
-        return;
-    }
-    // Hide libopenvino_c.so so OvEmbedder::try_new fails. ov_lib_path()
-    // checks OPENVINO_LIB_PATH first, so pointing it at /dev/null beats
-    // any other path on the host.
-    std::env::set_var("OPENVINO_LIB_PATH", "/dev/null");
-    summarizer::set_execution_provider("npu");
-
-    // Embedding should still succeed via CPU fallback.
-    let r = summarizer::embed_direct(vec!["x"]);
-    std::env::remove_var("OPENVINO_LIB_PATH");
-
-    assert!(r.is_ok(), "expected CPU fallback to succeed: {:?}", r.err());
-    assert!(
-        !summarizer::ov_embedder_is_active(),
-        "OV embedder must NOT be active when libopenvino is hidden"
-    );
-}

--- a/ccr-core/tests/npu_smoke.rs
+++ b/ccr-core/tests/npu_smoke.rs
@@ -1,0 +1,52 @@
+//! Feature-gated NPU smoke test.
+//!
+//! Skipped at compile time unless `--features openvino`; skipped at run time
+//! unless `OPENVINO_NPU_AVAILABLE=1`. The point is to verify that the
+//! OpenVINO EP can build a session for our default model on the host's NPU
+//! and that embeddings come back the right shape and L2-normalised.
+
+#![cfg(feature = "openvino")]
+
+use panda_core::summarizer;
+
+fn npu_opted_in() -> bool {
+    std::env::var("OPENVINO_NPU_AVAILABLE").ok().as_deref() == Some("1")
+}
+
+#[test]
+fn npu_smoke_embeds_three_strings() {
+    if !npu_opted_in() {
+        eprintln!("skipping: OPENVINO_NPU_AVAILABLE != 1");
+        return;
+    }
+    summarizer::set_execution_provider("npu");
+    let texts = vec!["error: build failed", "warning: deprecated", "ok"];
+    let embeddings = summarizer::embed_direct(texts).expect("embed_direct");
+    assert_eq!(embeddings.len(), 3, "expected 3 vectors");
+    for (i, v) in embeddings.iter().enumerate() {
+        assert_eq!(v.len(), 384, "vec {i} dim");
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!(
+            (norm - 1.0).abs() < 1e-3,
+            "vec {i} not L2-normalised: norm={norm}"
+        );
+    }
+}
+
+#[test]
+fn npu_falls_back_to_cpu_when_openvino_missing() {
+    if !npu_opted_in() {
+        eprintln!("skipping: OPENVINO_NPU_AVAILABLE != 1");
+        return;
+    }
+    // Hide the OV runtime so OpenVINO EP construction fails. The test only
+    // works if libopenvino_c.so isn't on a system path the loader will find
+    // anyway. On systems where it is, this test is a no-op and that's fine.
+    std::env::set_var("LD_LIBRARY_PATH", "/dev/null");
+    std::env::remove_var("PANDA_NPU_STRICT");
+    summarizer::set_execution_provider("npu");
+
+    // Construction should succeed via CPU fallback.
+    let r = summarizer::embed_direct(vec!["x"]);
+    assert!(r.is_ok(), "expected CPU fallback to succeed: {:?}", r.err());
+}

--- a/ccr-core/tests/npu_smoke.rs
+++ b/ccr-core/tests/npu_smoke.rs
@@ -1,9 +1,9 @@
 //! Feature-gated NPU smoke test.
 //!
 //! Skipped at compile time unless `--features openvino`; skipped at run time
-//! unless `OPENVINO_NPU_AVAILABLE=1`. The point is to verify that the
-//! OpenVINO EP can build a session for our default model on the host's NPU
-//! and that embeddings come back the right shape and L2-normalised.
+//! unless `OPENVINO_NPU_AVAILABLE=1`. Verifies the raw OpenVINO embedder
+//! actually engaged (asserts `ov_embedder_is_active()`), not just that some
+//! embedder produced 384-dim L2-normalised vectors.
 
 #![cfg(feature = "openvino")]
 
@@ -14,39 +14,56 @@ fn npu_opted_in() -> bool {
 }
 
 #[test]
-fn npu_smoke_embeds_three_strings() {
+fn npu_smoke_actually_uses_npu() {
     if !npu_opted_in() {
         eprintln!("skipping: OPENVINO_NPU_AVAILABLE != 1");
         return;
     }
     summarizer::set_execution_provider("npu");
     let texts = vec!["error: build failed", "warning: deprecated", "ok"];
+
+    let t0 = std::time::Instant::now();
     let embeddings = summarizer::embed_direct(texts).expect("embed_direct");
+    let elapsed = t0.elapsed();
+
     assert_eq!(embeddings.len(), 3, "expected 3 vectors");
     for (i, v) in embeddings.iter().enumerate() {
-        assert_eq!(v.len(), 384, "vec {i} dim");
+        assert_eq!(v.len(), 384, "vec {i} dim mismatch");
         let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
         assert!(
             (norm - 1.0).abs() < 1e-3,
             "vec {i} not L2-normalised: norm={norm}"
         );
     }
+
+    assert!(
+        summarizer::ov_embedder_is_active(),
+        "raw OV embedder must be active in NPU mode — without this assertion, \
+         a silent CPU fallback would let this test pass spuriously"
+    );
+
+    eprintln!("npu embed elapsed: {elapsed:?}");
 }
 
 #[test]
-fn npu_falls_back_to_cpu_when_openvino_missing() {
+fn npu_falls_back_to_cpu_when_libopenvino_missing() {
     if !npu_opted_in() {
         eprintln!("skipping: OPENVINO_NPU_AVAILABLE != 1");
         return;
     }
-    // Hide the OV runtime so OpenVINO EP construction fails. The test only
-    // works if libopenvino_c.so isn't on a system path the loader will find
-    // anyway. On systems where it is, this test is a no-op and that's fine.
-    std::env::set_var("LD_LIBRARY_PATH", "/dev/null");
-    std::env::remove_var("PANDA_NPU_STRICT");
+    // Hide libopenvino_c.so so OvEmbedder::try_new fails. ov_lib_path()
+    // checks OPENVINO_LIB_PATH first, so pointing it at /dev/null beats
+    // any other path on the host.
+    std::env::set_var("OPENVINO_LIB_PATH", "/dev/null");
     summarizer::set_execution_provider("npu");
 
-    // Construction should succeed via CPU fallback.
+    // Embedding should still succeed via CPU fallback.
     let r = summarizer::embed_direct(vec!["x"]);
+    std::env::remove_var("OPENVINO_LIB_PATH");
+
     assert!(r.is_ok(), "expected CPU fallback to succeed: {:?}", r.err());
+    assert!(
+        !summarizer::ov_embedder_is_active(),
+        "OV embedder must NOT be active when libopenvino is hidden"
+    );
 }

--- a/ccr/Cargo.toml
+++ b/ccr/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/main.rs"
 name = "panda"
 path = "src/lib.rs"
 
+[features]
+default = []
+openvino = ["panda-core/openvino"]
+
 [dependencies]
 panda-core = { path = "../ccr-core" }
 panda-sdk  = { path = "../ccr-sdk"  }

--- a/ccr/src/cmd/daemon.rs
+++ b/ccr/src/cmd/daemon.rs
@@ -153,10 +153,13 @@ fn daemon_main(sock_path: PathBuf, pid_path: PathBuf) -> Result<()> {
     #[cfg(feature = "openvino")]
     if panda_core::summarizer::current_ep() == "npu" {
         // Eagerly compile the model for NPU so the multi-second cost is
-        // paid here instead of on the first client embed call. If init
-        // fails the OV_EMBEDDER static caches None and subsequent calls
-        // go to CPU automatically.
-        let _ = panda_core::summarizer::preload_ov_embedder();
+        // paid here instead of on the first client embed call. Under
+        // PANDA_NPU_STRICT=1 a failure here is fatal; otherwise the
+        // OV_EMBEDDER static caches None and subsequent calls go to CPU.
+        if let Err(e) = panda_core::summarizer::preload_ov_embedder() {
+            eprintln!("[panda] daemon: {e}");
+            std::process::exit(1);
+        }
     }
     if panda_core::summarizer::preload_model().is_err() {
         std::process::exit(1);

--- a/ccr/src/cmd/daemon.rs
+++ b/ccr/src/cmd/daemon.rs
@@ -148,6 +148,7 @@ fn daemon_main(sock_path: PathBuf, pid_path: PathBuf) -> Result<()> {
         }
         panda_core::summarizer::set_model_name(&config.global.bert_model);
         panda_core::summarizer::set_ort_threads(config.global.ort_threads);
+        panda_core::summarizer::set_execution_provider(&config.global.execution_provider);
     }
     if panda_core::summarizer::preload_model().is_err() {
         std::process::exit(1);

--- a/ccr/src/cmd/daemon.rs
+++ b/ccr/src/cmd/daemon.rs
@@ -150,6 +150,14 @@ fn daemon_main(sock_path: PathBuf, pid_path: PathBuf) -> Result<()> {
         panda_core::summarizer::set_ort_threads(config.global.ort_threads);
         panda_core::summarizer::set_execution_provider(&config.global.execution_provider);
     }
+    #[cfg(feature = "openvino")]
+    if panda_core::summarizer::current_ep() == "npu" {
+        // Eagerly compile the model for NPU so the multi-second cost is
+        // paid here instead of on the first client embed call. If init
+        // fails the OV_EMBEDDER static caches None and subsequent calls
+        // go to CPU automatically.
+        let _ = panda_core::summarizer::preload_ov_embedder();
+    }
     if panda_core::summarizer::preload_model().is_err() {
         std::process::exit(1);
     }

--- a/ccr/src/main.rs
+++ b/ccr/src/main.rs
@@ -213,6 +213,7 @@ fn main() {
         panda_core::summarizer::set_model_name(&config.global.bert_model);
         panda_core::summarizer::set_nice_level(config.global.nice_level);
         panda_core::summarizer::set_ort_threads(config.global.ort_threads);
+        panda_core::summarizer::set_execution_provider(&config.global.execution_provider);
         panda_core::summarizer::set_extra_keep_patterns(config.global.hard_keep_patterns.clone());
     }
 

--- a/docs/superpowers/plans/2026-05-01-npu-on-ort.md
+++ b/docs/superpowers/plans/2026-05-01-npu-on-ort.md
@@ -1,0 +1,900 @@
+# NPU on Upstream ORT — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore Intel NPU acceleration on top of upstream's ORT-based panda by adding an opt-in `openvino` Cargo feature that enables ORT's OpenVINO execution provider.
+
+**Architecture:** Reset `main` to `upstream/main` (preserving fork's pre-merge work on an archive branch), then graft a small NPU patch series onto a fresh `feat/npu-on-ort` worktree. NPU lives behind the `openvino` feature flag and is wired into both the embedding daemon (which owns the warm session) and the in-process fallback path. CPU is always the last EP so ORT's per-op fallthrough handles ops the OpenVINO EP cannot compile.
+
+**Tech Stack:** Rust 2021, `ort` 2.0.0-rc.12 (OpenVINO EP), `tokenizers` 0.21, `hf-hub` 0.4, OpenVINO 2024+ runtime (`libopenvino_c.so`), Intel NPU 3720.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change type |
+|---|---|---|
+| `ccr-core/Cargo.toml` | Workspace deps + feature flags | Modify (add `openvino` feature) |
+| `ccr-core/src/config.rs` | `GlobalConfig` schema | Modify (add `execution_provider` field + default) |
+| `ccr-core/src/summarizer.rs` | EP resolver + EP-list construction in `MiniLmEmbedder::new` | Modify (add `EXECUTION_PROVIDER` static, `set_execution_provider`, `ep_choice`, EP list, fallback retry, observability) |
+| `ccr/src/cmd/daemon.rs` | Daemon init wiring | Modify (one new `set_execution_provider` call) |
+| `ccr/src/main.rs` | Non-daemon init wiring | Modify (one new `set_execution_provider` call) |
+| `ccr-core/src/summarizer.rs` (test module) | Unit tests for EP resolver | Modify (add `#[cfg(test)] mod ep_tests`) |
+| `ccr-core/tests/npu_smoke.rs` | Feature-gated NPU integration test | Create |
+| `README.md` | NPU usage docs | Modify (add "NPU support (opt-in)" section) |
+
+---
+
+## Task 0: Branch and worktree setup
+
+**Files:**
+- No code changes; git operations only.
+
+- [ ] **Step 1: From the main repo workspace, save current `main` as an archive branch**
+
+Run:
+```bash
+cd /home/smiie/github/homebrew-pandafilter
+git fetch upstream
+git branch archive/pre-upstream-merge main
+```
+Expected: `Branch 'archive/pre-upstream-merge' set up`. No working-tree change.
+
+- [ ] **Step 2: Reset local `main` to `upstream/main`**
+
+Run:
+```bash
+git checkout main
+git reset --hard upstream/main
+```
+Expected: `HEAD is now at 9546fb6 chore: update formula for v1.3.9`.
+
+- [ ] **Step 3: Confirm the spec doc survived the reset**
+
+The spec was committed on the *old* `main` (commit `b4f2f3a`). After reset it lives only on the archive branch. Cherry-pick it back onto the new `main` so future PRs reference it:
+```bash
+git cherry-pick b4f2f3a
+```
+Expected: `[main <new-sha>] docs: spec for NPU support on upstream ORT-based panda`. If the path doesn't exist on upstream (it doesn't), this is a clean cherry-pick.
+
+- [ ] **Step 4: Create the feature branch and isolated worktree**
+
+Run:
+```bash
+git worktree add -b feat/npu-on-ort .worktrees/npu-on-ort main
+cd .worktrees/npu-on-ort
+git status
+```
+Expected: `On branch feat/npu-on-ort`, working tree clean.
+
+- [ ] **Step 5: Verify upstream baseline builds**
+
+Run:
+```bash
+cargo build --release -p panda
+```
+Expected: Successful build. No `openvino` feature involved yet — sanity check that the upstream code compiles in this environment.
+
+- [ ] **Step 6: Commit nothing yet — proceed to Task 1**
+
+No commit. The worktree is the implementation surface for Tasks 1–8.
+
+---
+
+## Task 1: Add the `openvino` Cargo feature
+
+**Files:**
+- Modify: `ccr-core/Cargo.toml`
+
+- [ ] **Step 1: Add a `[features]` section to `ccr-core/Cargo.toml`**
+
+Open the file, find the existing `[dev-dependencies]` line, and *above* it add:
+```toml
+[features]
+default = []
+openvino = ["ort/openvino"]
+```
+
+Final file shape (relevant excerpt):
+```toml
+[dependencies]
+# ... existing deps unchanged ...
+ort = { version = "=2.0.0-rc.12", features = ["std", "ndarray", "download-binaries", "tls-native"], default-features = false }
+# ... rest unchanged ...
+
+[features]
+default = []
+openvino = ["ort/openvino"]
+
+[dev-dependencies]
+tempfile = "3"
+```
+
+- [ ] **Step 2: Verify default build still works**
+
+Run:
+```bash
+cargo build -p panda-core
+```
+Expected: clean build. The feature is opt-in; default has no behavior change.
+
+- [ ] **Step 3: Verify the feature-on build at least *attempts* to link OpenVINO**
+
+Run:
+```bash
+cargo build -p panda-core --features openvino 2>&1 | tail -20
+```
+Expected: Either a clean build (if `libopenvino_c.so` is on the linker path) or a *linker* error mentioning OpenVINO. A *compile* error means the feature wiring is wrong — fix before continuing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ccr-core/Cargo.toml
+git commit -m "feat(ccr-core): add opt-in openvino feature flag
+
+Wires through to ort/openvino so that --features openvino enables the
+OpenVINO execution provider for Intel NPU/GPU/CPU. No default-build
+change; existing builds are byte-identical."
+```
+
+---
+
+## Task 2: Add `execution_provider` field to config (TDD)
+
+**Files:**
+- Modify: `ccr-core/src/config.rs`
+- Test: `ccr-core/src/config.rs` (existing `#[cfg(test)] mod tests`, or create one)
+
+- [ ] **Step 1: Write the failing test**
+
+Open `ccr-core/src/config.rs`. Find or create the `#[cfg(test)] mod tests` block at the bottom of the file. Add:
+```rust
+#[cfg(test)]
+mod execution_provider_tests {
+    use super::*;
+
+    #[test]
+    fn execution_provider_defaults_to_auto() {
+        let cfg: CcrConfig = toml::from_str("").unwrap();
+        assert_eq!(cfg.global.execution_provider, "auto");
+    }
+
+    #[test]
+    fn execution_provider_round_trips() {
+        let cfg: CcrConfig = toml::from_str(
+            "[global]\nexecution_provider = \"npu\"\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.global.execution_provider, "npu");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cargo test -p panda-core execution_provider_tests
+```
+Expected: FAIL — `no field 'execution_provider' on type 'GlobalConfig'`.
+
+- [ ] **Step 3: Add the field to `GlobalConfig`**
+
+In `ccr-core/src/config.rs`, find the `GlobalConfig` struct. Add this field at the end of the struct (just before the closing brace), preserving the `#[serde(default)]` pattern used by the surrounding fields:
+```rust
+    /// Which ONNX Runtime execution provider to use for embeddings.
+    /// Values: "auto" (NPU if compiled with --features openvino, else CPU),
+    /// "cpu", "npu". Override at runtime with PANDA_NPU=cpu|npu.
+    #[serde(default = "default_execution_provider")]
+    pub execution_provider: String,
+```
+
+Then add the default function next to the other `default_*` fns at the bottom of the file (next to `default_ort_threads`):
+```rust
+fn default_execution_provider() -> String {
+    "auto".to_string()
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+cargo test -p panda-core execution_provider_tests
+```
+Expected: PASS — both tests green.
+
+- [ ] **Step 5: Run the full crate test suite to confirm no regression**
+
+Run:
+```bash
+cargo test -p panda-core
+```
+Expected: all existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ccr-core/src/config.rs
+git commit -m "feat(ccr-core): add execution_provider config field
+
+New global field defaults to 'auto'; values 'cpu' | 'npu' force a specific
+ORT execution provider. PANDA_NPU env var will override at runtime
+(wired in a follow-up commit)."
+```
+
+---
+
+## Task 3: EP resolver + setter in summarizer (TDD)
+
+**Files:**
+- Modify: `ccr-core/src/summarizer.rs`
+
+This task adds **only** the resolver and setter — not the EP-list integration. That comes in Task 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+At the bottom of `ccr-core/src/summarizer.rs`, append a new test module. (If a `#[cfg(test)] mod tests` block already exists, add these inside it; otherwise create the block.)
+
+```rust
+#[cfg(test)]
+mod ep_resolver_tests {
+    use super::ep_choice;
+
+    fn clear_env() {
+        std::env::remove_var("PANDA_NPU");
+    }
+
+    #[test]
+    fn auto_resolves_to_cpu_without_feature_flag() {
+        // Without `--features openvino`, "auto" must resolve to "cpu".
+        clear_env();
+        let resolved = ep_choice("auto");
+        #[cfg(not(feature = "openvino"))]
+        assert_eq!(resolved, "cpu");
+        #[cfg(feature = "openvino")]
+        assert_eq!(resolved, "npu");
+    }
+
+    #[test]
+    fn explicit_cpu_stays_cpu() {
+        clear_env();
+        assert_eq!(ep_choice("cpu"), "cpu");
+    }
+
+    #[test]
+    fn unknown_value_falls_back_to_cpu_without_panic() {
+        clear_env();
+        // Should not panic. Unknown values resolve like "auto".
+        let resolved = ep_choice("banana");
+        assert!(resolved == "cpu" || resolved == "npu");
+    }
+
+    #[test]
+    fn panda_npu_env_overrides_config() {
+        std::env::set_var("PANDA_NPU", "cpu");
+        assert_eq!(ep_choice("npu"), "cpu");
+        std::env::remove_var("PANDA_NPU");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cargo test -p panda-core ep_resolver_tests
+```
+Expected: FAIL — `cannot find function 'ep_choice' in this scope` (or similar).
+
+- [ ] **Step 3: Add the resolver and setter to `summarizer.rs`**
+
+Find the existing block in `summarizer.rs` that defines `MODEL_NAME`, `NICE_LEVEL`, `ORT_THREADS`, and their setters (around line 55–80 in the upstream file). Just *below* `set_ort_threads`, add:
+
+```rust
+static EXECUTION_PROVIDER: OnceCell<String> = OnceCell::new();
+
+/// Set the desired ORT execution provider. Values: "auto", "cpu", "npu".
+/// First call wins, mirroring `set_model_name` semantics.
+pub fn set_execution_provider(s: &str) {
+    let _ = EXECUTION_PROVIDER.set(s.to_string());
+}
+
+/// Resolve the configured execution provider into a concrete EP name.
+///
+/// Resolution order:
+///   1. If `PANDA_NPU` env var is set, it wins.
+///   2. Otherwise the `configured` argument (typically read from
+///      `EXECUTION_PROVIDER.get()`) is used.
+///   3. "auto" / unknown values resolve to "npu" if the openvino feature
+///      is compiled in, else "cpu".
+///
+/// Always returns either "cpu" or "npu" — never "auto".
+pub(crate) fn ep_choice(configured: &str) -> &'static str {
+    let raw = std::env::var("PANDA_NPU")
+        .ok()
+        .unwrap_or_else(|| configured.to_string());
+    match raw.as_str() {
+        "cpu" => "cpu",
+        "npu" => {
+            #[cfg(feature = "openvino")]
+            { "npu" }
+            #[cfg(not(feature = "openvino"))]
+            {
+                static WARNED: std::sync::Once = std::sync::Once::new();
+                WARNED.call_once(|| {
+                    eprintln!(
+                        "[panda] execution_provider=npu but binary built without \
+                         openvino feature; using CPU"
+                    );
+                });
+                "cpu"
+            }
+        }
+        _ => {
+            // "auto" or unknown — resolve based on compiled feature set.
+            #[cfg(feature = "openvino")]
+            { "npu" }
+            #[cfg(not(feature = "openvino"))]
+            { "cpu" }
+        }
+    }
+}
+
+/// Convenience: read the configured EP from the static and resolve it.
+pub(crate) fn current_ep() -> &'static str {
+    let configured = EXECUTION_PROVIDER
+        .get()
+        .map(|s| s.as_str())
+        .unwrap_or("auto");
+    ep_choice(configured)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cargo test -p panda-core ep_resolver_tests
+```
+Expected: PASS — all four tests green.
+
+Note: tests share process state via env vars. If they fail intermittently, add `#[serial_test::serial]` later — for now sequencing in source order is fine because cargo's default test threading still runs each test once and each test resets the env it touches.
+
+- [ ] **Step 5: Confirm whole-crate tests still pass**
+
+Run:
+```bash
+cargo test -p panda-core
+```
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ccr-core/src/summarizer.rs
+git commit -m "feat(ccr-core): add ep_choice resolver and EXECUTION_PROVIDER setter
+
+Resolves config string + PANDA_NPU env override into a concrete EP name.
+Pure function — no ORT integration yet. Unit-tested for the four
+relevant cases: feature-off auto, explicit cpu, unknown value, env
+override."
+```
+
+---
+
+## Task 4: Wire EP list into `MiniLmEmbedder::new` with CPU-only retry
+
+**Files:**
+- Modify: `ccr-core/src/summarizer.rs`
+
+- [ ] **Step 1: Read the current `MiniLmEmbedder::new` to confirm structure**
+
+Run:
+```bash
+grep -n "fn new" ccr-core/src/summarizer.rs
+sed -n '110,160p' ccr-core/src/summarizer.rs
+```
+Expected: confirms the function builds an `ort::session::Session::builder()` and calls `with_execution_providers([ort::ep::CPU::default()...])`.
+
+- [ ] **Step 2: Replace the EP-list block in `MiniLmEmbedder::new`**
+
+Locate this block in `impl MiniLmEmbedder { fn new(...) {`:
+
+```rust
+        let mut builder = ort::session::Session::builder().map_err(ort_err)?;
+        builder = builder
+            .with_optimization_level(ort::session::builder::GraphOptimizationLevel::Level3)
+            .map_err(ort_err)?;
+        builder = builder.with_memory_pattern(false).map_err(ort_err)?;
+        builder = builder.with_intra_threads(threads).map_err(ort_err)?;
+        builder = builder
+            .with_execution_providers([ort::ep::CPU::default().with_arena_allocator(false).build()])
+            .map_err(ort_err)?;
+        let session = builder.commit_from_file(&model_path).map_err(ort_err)?;
+```
+
+Replace it with:
+
+```rust
+        // Build the EP list. CPU is always last so ORT can per-op fall through
+        // when the accelerator EP can't compile a node.
+        let strict = std::env::var("PANDA_NPU_STRICT").ok().as_deref() == Some("1");
+        let chosen_ep = current_ep();
+
+        let build_session = |use_npu: bool| -> anyhow::Result<ort::session::Session> {
+            let mut b = ort::session::Session::builder().map_err(ort_err)?;
+            b = b
+                .with_optimization_level(ort::session::builder::GraphOptimizationLevel::Level3)
+                .map_err(ort_err)?;
+            b = b.with_memory_pattern(false).map_err(ort_err)?;
+            b = b.with_intra_threads(threads).map_err(ort_err)?;
+
+            let mut eps: Vec<ort::ep::ExecutionProviderDispatch> = Vec::new();
+            #[cfg(feature = "openvino")]
+            if use_npu {
+                eps.push(
+                    ort::ep::OpenVINO::default()
+                        .with_device_type("NPU")
+                        .build()
+                        .into(),
+                );
+            }
+            // Suppress the "unused" warning when the openvino feature is off.
+            let _ = use_npu;
+            eps.push(
+                ort::ep::CPU::default()
+                    .with_arena_allocator(false)
+                    .build()
+                    .into(),
+            );
+
+            b = b.with_execution_providers(eps).map_err(ort_err)?;
+            b.commit_from_file(&model_path).map_err(ort_err)
+        };
+
+        let want_npu = chosen_ep == "npu";
+        let session = match build_session(want_npu) {
+            Ok(s) => {
+                eprintln!(
+                    "[panda] embedder: {} on {}",
+                    name,
+                    if want_npu { "NPU" } else { "CPU" }
+                );
+                s
+            }
+            Err(e) if want_npu && !strict => {
+                eprintln!(
+                    "[panda] OpenVINO EP unavailable: {e}; falling back to CPU"
+                );
+                let s = build_session(false)?;
+                eprintln!("[panda] embedder: {} on CPU (fallback)", name);
+                s
+            }
+            Err(e) => return Err(e),
+        };
+```
+
+- [ ] **Step 3: Build to confirm the closure compiles cleanly without the openvino feature**
+
+Run:
+```bash
+cargo build -p panda-core
+```
+Expected: clean build. (The `#[cfg(feature = "openvino")]` block is absent; `use_npu` is consumed by `let _ = use_npu;`.)
+
+- [ ] **Step 4: Build with the feature on**
+
+Run:
+```bash
+cargo build -p panda-core --features openvino 2>&1 | tail -20
+```
+Expected: clean compile. Linker may fail if `libopenvino_c.so` isn't installed — that's environmental, not a code defect.
+
+- [ ] **Step 5: Run all panda-core tests with feature off**
+
+Run:
+```bash
+cargo test -p panda-core
+```
+Expected: all pass. The new code path is gated; test behavior unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ccr-core/src/summarizer.rs
+git commit -m "feat(ccr-core): use OpenVINO EP when configured, fallback to CPU
+
+MiniLmEmbedder::new now builds [OpenVINO(NPU), CPU] when the openvino
+feature is on and the resolved EP is npu; falls back to [CPU] only on
+session-creation failure (unless PANDA_NPU_STRICT=1). CPU is always the
+final EP so ORT per-op fallthrough handles unsupported nodes.
+
+Logs which EP actually loaded on every session creation."
+```
+
+---
+
+## Task 5: Wire `set_execution_provider` into daemon and main
+
+**Files:**
+- Modify: `ccr/src/cmd/daemon.rs`
+- Modify: `ccr/src/main.rs`
+
+- [ ] **Step 1: Daemon — add the setter call**
+
+In `ccr/src/cmd/daemon.rs`, locate the block (around line 149–150 in upstream):
+```rust
+        panda_core::summarizer::set_model_name(&config.global.bert_model);
+        panda_core::summarizer::set_ort_threads(config.global.ort_threads);
+```
+
+Add a third line *immediately after*:
+```rust
+        panda_core::summarizer::set_execution_provider(&config.global.execution_provider);
+```
+
+- [ ] **Step 2: Main — add the setter call**
+
+In `ccr/src/main.rs`, locate the block (around line 213–215):
+```rust
+        panda_core::summarizer::set_model_name(&config.global.bert_model);
+        panda_core::summarizer::set_ort_threads(config.global.ort_threads);
+```
+
+Add immediately after:
+```rust
+        panda_core::summarizer::set_execution_provider(&config.global.execution_provider);
+```
+
+- [ ] **Step 3: Build the whole workspace**
+
+Run:
+```bash
+cargo build -p panda
+```
+Expected: clean build.
+
+- [ ] **Step 4: Run all workspace tests**
+
+Run:
+```bash
+cargo test
+```
+Expected: all pass.
+
+- [ ] **Step 5: Smoke-test the foreground path**
+
+Run:
+```bash
+echo "warning: deprecated\nerror: foo\nok\nok\nok\nok\nok\nok\nok\nok\nok\nok\nok\nok\nok" \
+  | ./target/debug/panda filter --command cargo
+```
+Expected: filter output, and on stderr a single `[panda] embedder: AllMiniLML6V2 on CPU` line. (CPU because the default build has no openvino feature.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ccr/src/cmd/daemon.rs ccr/src/main.rs
+git commit -m "feat(ccr): wire execution_provider config into daemon and CLI init
+
+Both the embedding daemon and the foreground panda process now call
+set_execution_provider after loading config, mirroring the existing
+set_model_name / set_ort_threads pattern."
+```
+
+---
+
+## Task 6: Feature-gated NPU smoke test
+
+**Files:**
+- Create: `ccr-core/tests/npu_smoke.rs`
+
+- [ ] **Step 1: Write the integration test file**
+
+Create `ccr-core/tests/npu_smoke.rs` with:
+
+```rust
+//! Feature-gated NPU smoke test.
+//!
+//! Skipped at compile time unless `--features openvino`; skipped at run time
+//! unless `OPENVINO_NPU_AVAILABLE=1`. The point is to verify that the
+//! OpenVINO EP can build a session for our default model on the host's NPU
+//! and that embeddings come back the right shape and L2-normalised.
+
+#![cfg(feature = "openvino")]
+
+use panda_core::summarizer;
+
+fn npu_opted_in() -> bool {
+    std::env::var("OPENVINO_NPU_AVAILABLE").ok().as_deref() == Some("1")
+}
+
+#[test]
+fn npu_smoke_embeds_three_strings() {
+    if !npu_opted_in() {
+        eprintln!("skipping: OPENVINO_NPU_AVAILABLE != 1");
+        return;
+    }
+    summarizer::set_execution_provider("npu");
+    let texts = vec!["error: build failed", "warning: deprecated", "ok"];
+    let embeddings = summarizer::embed_direct(texts).expect("embed_direct");
+    assert_eq!(embeddings.len(), 3, "expected 3 vectors");
+    for (i, v) in embeddings.iter().enumerate() {
+        assert_eq!(v.len(), 384, "vec {i} dim");
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!(
+            (norm - 1.0).abs() < 1e-3,
+            "vec {i} not L2-normalised: norm={norm}"
+        );
+    }
+}
+
+#[test]
+fn npu_falls_back_to_cpu_when_openvino_missing() {
+    if !npu_opted_in() {
+        eprintln!("skipping: OPENVINO_NPU_AVAILABLE != 1");
+        return;
+    }
+    // Hide the OV runtime so OpenVINO EP construction fails. The test only
+    // works if libopenvino_c.so isn't on a system path the loader will find
+    // anyway. On systems where it is, this test is a no-op and that's fine.
+    std::env::set_var("LD_LIBRARY_PATH", "/dev/null");
+    std::env::remove_var("PANDA_NPU_STRICT");
+    summarizer::set_execution_provider("npu");
+
+    // Construction should succeed via CPU fallback.
+    let r = summarizer::embed_direct(vec!["x"]);
+    assert!(r.is_ok(), "expected CPU fallback to succeed: {:?}", r.err());
+}
+```
+
+- [ ] **Step 2: Verify the file compiles when feature is off (becomes empty)**
+
+Run:
+```bash
+cargo build -p panda-core --tests
+```
+Expected: clean build. Without `--features openvino`, the `#![cfg(...)]` makes the file inert.
+
+- [ ] **Step 3: Verify the file compiles with feature on**
+
+Run:
+```bash
+cargo build -p panda-core --tests --features openvino 2>&1 | tail -10
+```
+Expected: clean compile. Linker may fail if OpenVINO isn't installed; that's environmental.
+
+- [ ] **Step 4: Run the smoke test (skipped without env var)**
+
+Run:
+```bash
+cargo test -p panda-core --features openvino --test npu_smoke
+```
+Expected: tests run and silently skip with `skipping: OPENVINO_NPU_AVAILABLE != 1` unless the env var is set.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ccr-core/tests/npu_smoke.rs
+git commit -m "test(ccr-core): add feature-gated NPU smoke test
+
+Verifies that with --features openvino, the embedder produces the
+expected shape and L2-normalised vectors via OpenVINO NPU. Also
+verifies that hiding libopenvino_c.so triggers the CPU fallback path
+without surfacing the error.
+
+Skipped silently unless OPENVINO_NPU_AVAILABLE=1, so CI machines
+without an NPU don't fail."
+```
+
+---
+
+## Task 7: README — NPU section
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Read the current README to find a sensible insertion point**
+
+Run:
+```bash
+grep -nE '^## |^### ' README.md | head -30
+```
+Expected: section list. Pick a spot after the install/getting-started section but before deep-internals.
+
+- [ ] **Step 2: Add the NPU section**
+
+Append (or insert at the chosen location) the following section:
+
+````markdown
+## NPU support (opt-in, Intel only)
+
+Panda's embedding model can run on an Intel NPU (e.g. Meteor Lake NPU 3720)
+through ONNX Runtime's OpenVINO execution provider. This is opt-in.
+
+### Build
+
+```bash
+cargo build --release --features openvino
+```
+
+Requires the OpenVINO 2024+ runtime — specifically `libopenvino_c.so` —
+discoverable at runtime (typically via `LD_LIBRARY_PATH` or a system
+package). `ort` itself ships the ONNX Runtime binary; only the OpenVINO
+runtime is your responsibility.
+
+### Configure
+
+In `panda.toml` (project or `~/.config/panda/config.toml`):
+
+```toml
+[global]
+execution_provider = "npu"   # "auto" | "cpu" | "npu"
+```
+
+Or override at runtime:
+
+```bash
+PANDA_NPU=npu panda daemon start    # force NPU for this daemon
+PANDA_NPU=cpu panda run cargo build # force CPU for this invocation
+```
+
+### How it works
+
+The first call to the embedder pays a one-time OpenVINO compile cost
+(~3–10 s on NPU 3720), cached on disk by OpenVINO under
+`~/.cache/OpenVINO/`. Run `panda daemon start` once at the beginning of
+a session and every subsequent embedding is sub-millisecond dispatch
+overhead from the warm session.
+
+If the OpenVINO EP fails to build a session (driver missing, NPU busy,
+unsupported op), panda silently falls back to CPU and logs one line on
+stderr. To make these failures fatal — useful when diagnosing whether
+the NPU is actually being used — set `PANDA_NPU_STRICT=1`.
+````
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add 'NPU support (opt-in)' section to README"
+```
+
+---
+
+## Task 8: Manual verification
+
+**Files:**
+- None — runs the binaries against real workloads.
+
+This is the verification-before-completion gate from the spec. Do NOT skip.
+
+- [ ] **Step 1: Default build is byte-clean**
+
+Run:
+```bash
+cargo build --release -p panda
+./target/release/panda run ls 2>&1 | tail -5
+```
+Expected: clean build, normal `ls` output.
+
+- [ ] **Step 2: Feature-on build links and runs**
+
+Run:
+```bash
+cargo build --release -p panda --features openvino
+./target/release/panda run ls 2>&1 | tail -5
+```
+Expected: clean build (assuming OpenVINO runtime present), normal output. Stderr should show a `[panda] embedder: ... on NPU` or `on CPU` line if BERT was triggered.
+
+- [ ] **Step 3: Daemon up on NPU**
+
+In `panda.toml` set `execution_provider = "npu"`, then:
+```bash
+./target/release/panda daemon stop 2>/dev/null
+./target/release/panda daemon start
+sleep 12
+./target/release/panda daemon status
+journalctl --user -t panda --since "1 minute ago" 2>/dev/null \
+  || cat ~/.local/state/panda/daemon.log 2>/dev/null \
+  || echo "(no log capture configured — check ps/strace if needed)"
+```
+Expected: `daemon running`. If a log surface is configured, look for `[panda] embedder: AllMiniLML6V2 on NPU`. First-call latency under ~15 s.
+
+- [ ] **Step 4: Toggle off, re-verify CPU**
+
+Edit `panda.toml` to `execution_provider = "cpu"`, then:
+```bash
+./target/release/panda daemon stop
+./target/release/panda daemon start
+sleep 3
+```
+Expected: daemon up; whatever log surface you used in Step 3 now shows `on CPU`.
+
+- [ ] **Step 5: Strict mode fails loud when OV missing**
+
+Run:
+```bash
+./target/release/panda daemon stop
+LD_LIBRARY_PATH=/dev/null PANDA_NPU=npu PANDA_NPU_STRICT=1 \
+  ./target/release/panda daemon start
+sleep 2
+./target/release/panda daemon status
+```
+Expected: daemon does NOT come up (status reports not running), error visible. Re-clear strict mode after this step.
+
+- [ ] **Step 6: Real workload**
+
+```bash
+./target/release/panda daemon stop
+./target/release/panda daemon start  # back to whatever exec provider you want
+./target/release/panda run cargo build -p panda 2>&1 | tail -20
+./target/release/panda run git status 2>&1 | tail -10
+./target/release/panda gain
+```
+Expected: outputs look reasonable — not garbled, no `[panda] OpenVINO EP unavailable` storms. `panda gain` shows non-zero token savings.
+
+- [ ] **Step 7: Run the smoke test on the real machine**
+
+```bash
+OPENVINO_NPU_AVAILABLE=1 cargo test -p panda-core --features openvino --test npu_smoke -- --nocapture
+```
+Expected: `npu_smoke_embeds_three_strings` passes. If it fails, the OpenVINO EP can't actually compile MiniLM on this NPU — escalate to the spec's "raw OpenVINO bypass" follow-up before declaring done.
+
+- [ ] **Step 8: Final sanity — full test suite**
+
+```bash
+cargo test
+cargo test --features openvino
+```
+Expected: all pass.
+
+- [ ] **Step 9: Push and open PR**
+
+```bash
+git push -u origin feat/npu-on-ort
+gh pr create --base main --title "feat: NPU support on upstream ORT (opt-in)" \
+  --body-file - <<'EOF'
+Restores Intel NPU acceleration on top of upstream/main (post ort-migration)
+as an opt-in `openvino` Cargo feature. Spec:
+docs/superpowers/specs/2026-05-01-npu-on-upstream-ort-design.md
+
+- Adds `[features] openvino = ["ort/openvino"]` in ccr-core.
+- New `execution_provider` config field (`auto` | `cpu` | `npu`).
+- `MiniLmEmbedder::new` builds `[OpenVINO(NPU), CPU]` when configured;
+  falls back to `[CPU]` on session-creation failure unless
+  `PANDA_NPU_STRICT=1`.
+- Daemon and foreground init paths both honour the config.
+- Smoke test gated on `--features openvino` + `OPENVINO_NPU_AVAILABLE=1`.
+- README section documents the NPU workflow.
+
+Default builds are byte-identical to upstream — no behavior change for
+users who don't pass `--features openvino`.
+EOF
+```
+Expected: PR opened. Link printed by `gh`.
+
+---
+
+## Self-Review Notes
+
+Spec coverage check:
+- `[features] openvino` — Task 1 ✓
+- `execution_provider` config field — Task 2 ✓
+- `set_execution_provider` + `ep_choice` resolver — Task 3 ✓
+- EP-list construction with CPU fallback retry — Task 4 ✓
+- Daemon + main wiring — Task 5 ✓
+- Unit tests (3 resolver tests) — Task 3 ✓ (covers the spec's 3 cases)
+- Feature-gated integration tests (2) — Task 6 ✓
+- README — Task 7 ✓
+- Manual verification checklist — Task 8 ✓
+- Branch strategy (archive + worktree) — Task 0 ✓
+
+Type/name consistency:
+- `set_execution_provider(s: &str)` matches across all callers and the Section 2 spec.
+- `ep_choice(configured: &str) -> &'static str` and `current_ep() -> &'static str` are the two helpers; the integration in Task 4 uses `current_ep()` (the `EXECUTION_PROVIDER`-reading variant) while the unit tests in Task 3 exercise the pure `ep_choice(arg)` variant — intentional separation.
+- The observability `eprintln!` format `[panda] embedder: {name} on {NPU|CPU}` matches the spec.
+- `PANDA_NPU_STRICT=1` is honoured in Task 4's `Err(e) if want_npu && !strict` arm — matches the spec.
+
+No placeholders. No "implement later". Every step has either a code block, a command, or a git operation.

--- a/docs/superpowers/plans/2026-05-01-npu-raw-openvino-bypass.md
+++ b/docs/superpowers/plans/2026-05-01-npu-raw-openvino-bypass.md
@@ -1,0 +1,1102 @@
+# Raw OpenVINO Bypass — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore Intel NPU acceleration on top of upstream's ORT-based panda by porting `archive/pre-upstream-merge:ccr-core/src/ov_embed.rs` forward and grafting it onto the resolver/daemon scaffolding from Approach A.
+
+**Architecture:** The `--features openvino` Cargo feature is repointed: instead of activating ORT's broken OpenVINO EP, it pulls in the `openvino-rs` crates and registers an `OvEmbedder` that runs ahead of the ORT-CPU path inside `embed_and_normalize`. The Approach A scaffolding (config field, `current_ep` resolver, `set_execution_provider`, daemon wiring) is reused verbatim; only `MiniLmEmbedder::new` reverts to upstream's flat `[CPU]` builder.
+
+**Tech Stack:** Rust 2021, `openvino`/`openvino-sys` from `intel/openvino-rs` rev `e25f1f848edc` with `runtime-linking`, OpenVINO 2024+ runtime (`libopenvino_c.so`, default search includes `~/.local/share/ccr/onnxruntime/`), Intel NPU 3720, `tokenizers` 0.21, `hf-hub` 0.4 (reused via `summarizer::resolve_model_files`).
+
+**Branch:** continues on `feat/npu-on-ort`. Prerequisite: Approach A's 9 commits (`e1ca02a` → `7a7bf2a`) are already in place. This plan adds 7 new commits on top.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change type |
+|---|---|---|
+| `ccr-core/Cargo.toml` | Replace `ort/openvino` feature wiring with `openvino-rs` deps | Modify |
+| `ccr-core/src/lib.rs` | Declare `ov_embed` module gated on the feature | Modify |
+| `ccr-core/src/ov_embed.rs` | Direct OpenVINO C-API embedder (Core, compiled model, async InferRequest pool, NPU compile cache, degradation flag) | Create (port from archive) |
+| `ccr-core/src/summarizer.rs` | Revert `MiniLmEmbedder::new` to upstream's flat `[CPU]`. Add `OV_EMBEDDER` static, `get_ov_embedder`, `preload_ov_embedder`, `ov_embedder_is_active`. Wire OV dispatch into `embed_and_normalize` and `embed_direct`. Move CPU "embedder loaded" log into `MODEL_CACHE.get_or_try_init`. Make `current_ep` `pub`. | Modify |
+| `ccr/src/cmd/daemon.rs` | Eager `preload_ov_embedder` call when configured | Modify |
+| `ccr-core/tests/npu_smoke.rs` | Replace Approach A assertions with sharper ones using `ov_embedder_is_active` | Modify |
+| `README.md` | Rewrite NPU section to describe the raw bypass | Modify |
+
+No file becomes large enough to need splitting. `ov_embed.rs` is ~400 lines, single responsibility (NPU embedding). `summarizer.rs` already exceeds 1900 lines pre-existing — we don't restructure it; we only add to its existing patterns.
+
+---
+
+## Task 1: Revert `MiniLmEmbedder::new` to upstream's flat `[CPU]` builder
+
+**Why first:** Approach A's closure-based EP list is dead weight under Approach B (no caller asks `MiniLmEmbedder` for an NPU session anymore). Reverting now keeps the diff readable when later tasks add the OV path.
+
+**Files:**
+- Modify: `ccr-core/src/summarizer.rs`
+
+- [ ] **Step 1: Confirm the current `MiniLmEmbedder::new` has the Approach A closure**
+
+Run:
+```bash
+cd /home/smiie/github/homebrew-pandafilter/.worktrees/npu-on-ort
+grep -n "let build_session\|chosen_ep\|fn new" ccr-core/src/summarizer.rs | head
+```
+Expected output includes a line like `let build_session = |use_npu: bool| ...`. If that line is missing, stop — branch state is unexpected.
+
+- [ ] **Step 2: Replace the closure block with upstream's flat builder**
+
+Open `ccr-core/src/summarizer.rs`. Locate the entire block inside `impl MiniLmEmbedder { fn new(name: &str) -> ... {` from the line `// Build the EP list. CPU is always last so ORT can per-op fall through` through `Err(e) => return Err(e), };` (about 50 lines).
+
+Replace it with this exact block:
+
+```rust
+        let mut builder = ort::session::Session::builder().map_err(ort_err)?;
+        builder = builder
+            .with_optimization_level(ort::session::builder::GraphOptimizationLevel::Level3)
+            .map_err(ort_err)?;
+        builder = builder.with_memory_pattern(false).map_err(ort_err)?;
+        builder = builder.with_intra_threads(threads).map_err(ort_err)?;
+        builder = builder
+            .with_execution_providers([ort::ep::CPU::default().with_arena_allocator(false).build()])
+            .map_err(ort_err)?;
+        let session = builder.commit_from_file(&model_path).map_err(ort_err)?;
+```
+
+This is verbatim upstream. The eprintln moves to Task 6.
+
+- [ ] **Step 3: Build to confirm compile**
+
+Run:
+```bash
+cargo build -p panda-core
+```
+Expected: clean build. The unused `current_ep` warning may appear — that's fine for now; Task 6 re-uses it.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+```bash
+cargo test -p panda-core
+```
+Expected: all tests pass (including `ep_resolver_tests` and `execution_provider_tests` from Approach A).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ccr-core/src/summarizer.rs
+git commit -m "refactor(ccr-core): revert MiniLmEmbedder to upstream flat [CPU] builder" -m "Approach A's closure-based EP-list with CPU fallback retry was scaffolding for the ort OpenVINO EP path, which empirical verification showed cannot engage on Meteor Lake with ort 2.0.0-rc.12. The raw OpenVINO bypass (next commits) makes the closure dead code. Reverting to upstream's exact builder makes that obvious and shrinks the diff." -m "MiniLmEmbedder is now strictly the CPU fallback path."
+```
+
+---
+
+## Task 2: Repoint `openvino` Cargo feature to `openvino-rs` crates
+
+**Files:**
+- Modify: `ccr-core/Cargo.toml`
+
+- [ ] **Step 1: Update `ccr-core/Cargo.toml`**
+
+Open `ccr-core/Cargo.toml`. The current state has these two relevant blocks (left in place by Approach A):
+
+```toml
+ort = { version = "=2.0.0-rc.12", features = ["std", "ndarray", "download-binaries", "tls-native"], default-features = false }
+# ... other deps ...
+
+[features]
+default = []
+openvino = ["ort/openvino"]
+```
+
+Replace the `[features]` block and add two new optional dependencies. Final relevant excerpt:
+
+```toml
+[dependencies]
+regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+toml.workspace = true
+anyhow.workspace = true
+thiserror.workspace = true
+tiktoken-rs.workspace = true
+once_cell = "1"
+libc = "0.2"
+ort = { version = "=2.0.0-rc.12", features = ["std", "ndarray", "download-binaries", "tls-native"], default-features = false }
+tokenizers = { version = "0.21", features = ["onig"], default-features = false }
+ndarray = "0.17"
+hf-hub = { version = "0.4", features = ["ureq", "native-tls"] }
+rusqlite = { version = "0.31", features = ["bundled"] }
+walkdir = "2"
+openvino = { git = "https://github.com/intel/openvino-rs", rev = "e25f1f848edc", features = ["runtime-linking"], optional = true }
+openvino-sys = { git = "https://github.com/intel/openvino-rs", rev = "e25f1f848edc", features = ["runtime-linking"], optional = true }
+
+[features]
+default = []
+openvino = ["dep:openvino", "dep:openvino-sys"]
+
+[dev-dependencies]
+tempfile = "3"
+```
+
+Don't touch `ort`'s features — the bypass coexists with ORT (CPU only) in default builds; we just don't ask ORT for OpenVINO anymore.
+
+- [ ] **Step 2: Verify default build is unchanged**
+
+Run:
+```bash
+cargo build -p panda-core
+```
+Expected: clean build. `Cargo.lock` may pick up the optional `openvino` git dep info but won't activate it.
+
+- [ ] **Step 3: Verify feature-on build (link only — no NPU touched yet)**
+
+Run:
+```bash
+cargo build -p panda-core --features openvino 2>&1 | tail -10
+```
+Expected: clean compile and link. `runtime-linking` means no link-time `libopenvino_c.so` requirement. If you see compile errors from the `openvino` crate, the rev pin is wrong — stop and report.
+
+`ccr/Cargo.toml`'s `openvino = ["panda-core/openvino"]` forwarding feature was added in Approach A and stays unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ccr-core/Cargo.toml
+git commit -m "feat(ccr-core): repoint openvino feature to openvino-rs crates" -m "Replaces the broken ort/openvino EP wiring with the openvino + openvino-sys git deps from intel/openvino-rs (rev e25f1f848edc, runtime-linking). Same rev that worked on this hardware before the upstream merge — proven path." -m "No code consumes the new deps yet; that's added in the next commits."
+```
+
+---
+
+## Task 3: Port `ov_embed.rs` from `archive/pre-upstream-merge`
+
+**Files:**
+- Create: `ccr-core/src/ov_embed.rs`
+- Modify: `ccr-core/src/lib.rs`
+
+- [ ] **Step 1: Copy the archived file verbatim into the worktree**
+
+Run:
+```bash
+cd /home/smiie/github/homebrew-pandafilter/.worktrees/npu-on-ort
+git show archive/pre-upstream-merge:ccr-core/src/ov_embed.rs > ccr-core/src/ov_embed.rs
+wc -l ccr-core/src/ov_embed.rs
+```
+Expected: ~401 lines.
+
+- [ ] **Step 2: Trim `model_onnx_info` to just the two upstream-supported models, and replace it with `model_seq_len`**
+
+Open `ccr-core/src/ov_embed.rs`. Find the `pub fn model_onnx_info(...)` function (the one with the 16-arm match). Replace the entire function with:
+
+```rust
+/// Per-model NPU sequence length. Returns `None` for unknown models — caller
+/// should fall through to the CPU embedder.
+///
+/// Mirrors the model registry in `summarizer::model_registry`. When new
+/// models are added there, add their NPU `seq_len` here.
+pub fn model_seq_len(model_name: &str) -> Option<usize> {
+    match model_name {
+        "AllMiniLML6V2" => Some(128),
+        "AllMiniLML12V2" => Some(128),
+        _ => None,
+    }
+}
+```
+
+The 16-model table goes away — we'll restore it in a separate follow-up when the broader model set comes back.
+
+- [ ] **Step 3: Delete `find_fastembed_onnx`**
+
+Find and delete the entire `pub fn find_fastembed_onnx(...) -> Option<(PathBuf, PathBuf, usize)>` function (the one that walks the fastembed cache). Upstream's `summarizer::resolve_model_files` replaces it.
+
+- [ ] **Step 4: Adjust `ov_lib_path` visibility**
+
+The function `fn ov_lib_path()` at the top of the file is currently private. The unit tests in Task 8 will exercise it via `ov_embed::ov_lib_path`. Change its signature from:
+
+```rust
+fn ov_lib_path() -> Option<PathBuf> {
+```
+
+to:
+
+```rust
+pub fn ov_lib_path() -> Option<PathBuf> {
+```
+
+(Just `pub fn` — module-level visibility is enough since `ov_embed` is `pub(crate)`.)
+
+- [ ] **Step 5: Add the module declaration to `lib.rs`**
+
+Open `ccr-core/src/lib.rs`. Find the existing `pub mod` list near the top:
+
+```rust
+pub mod analytics;
+pub mod ansi;
+pub mod global_rules;
+pub mod config;
+pub mod delta;
+pub mod embed_client;
+pub mod focus;
+pub mod jsonlog;
+pub mod ndjson;
+pub mod patterns;
+```
+
+Add immediately after `pub mod patterns;`:
+
+```rust
+#[cfg(feature = "openvino")]
+pub(crate) mod ov_embed;
+```
+
+Keep alphabetical placement if the file uses it; otherwise the position right after `patterns` is fine.
+
+- [ ] **Step 6: Build with feature off (file should be inert)**
+
+Run:
+```bash
+cargo build -p panda-core
+```
+Expected: clean build. The `ov_embed` module is excluded by `#[cfg(feature = "openvino")]`.
+
+- [ ] **Step 7: Build with feature on**
+
+Run:
+```bash
+cargo build -p panda-core --features openvino 2>&1 | tail -20
+```
+Expected: clean compile. The `openvino`/`openvino-sys` crates compile and link via `runtime-linking`. You may see warnings about unused `Send`/`Sync` impls — leave them; they're conservative safety markers from the original.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ccr-core/src/ov_embed.rs ccr-core/src/lib.rs
+git commit -m "feat(ccr-core): restore ov_embed.rs as raw OpenVINO NPU embedder" -m "Near-verbatim port from archive/pre-upstream-merge. Two surgical edits: 1) model_onnx_info replaced with a 2-arm model_seq_len matching upstream's slim model_registry (full table follows in a separate restore-models commit); 2) find_fastembed_onnx removed because hf_hub-based summarizer::resolve_model_files supersedes it." -m "Public surface: try_new, embed, is_degraded, mark_degraded, model_seq_len, ov_lib_path. Module is gated on --features openvino."
+```
+
+---
+
+## Task 4: Add `OV_EMBEDDER` static + accessors in `summarizer.rs`
+
+**Files:**
+- Modify: `ccr-core/src/summarizer.rs`
+
+- [ ] **Step 1: Locate the insertion point**
+
+Run:
+```bash
+grep -n "static MODEL_CACHE\|pub fn preload_model" ccr-core/src/summarizer.rs
+```
+Expected: `static MODEL_CACHE` near the bottom of the embedder section, followed by `fn get_model`, then `pub fn preload_model`.
+
+- [ ] **Step 2: Add the OV embedder static and accessors right after `pub fn preload_model`**
+
+Open `ccr-core/src/summarizer.rs`. Find the `pub fn preload_model() -> anyhow::Result<()>` function. Immediately after its closing brace, insert:
+
+```rust
+// ── Raw OpenVINO bypass (opt-in via --features openvino) ─────────────────────
+
+#[cfg(feature = "openvino")]
+static OV_EMBEDDER: OnceCell<Option<crate::ov_embed::OvEmbedder>> = OnceCell::new();
+
+/// Lazily construct the OV embedder. Returns `None` (cached) on any failure
+/// or once `is_degraded()` flips. Idempotent and process-lifetime stable.
+#[cfg(feature = "openvino")]
+fn get_ov_embedder() -> Option<&'static crate::ov_embed::OvEmbedder> {
+    if crate::ov_embed::is_degraded() {
+        return None;
+    }
+    OV_EMBEDDER
+        .get_or_init(|| {
+            let name = get_model_name();
+            let (onnx, tok) = match resolve_model_files(name) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("[panda] OV bypass: model fetch failed: {e}");
+                    return None;
+                }
+            };
+            let seq_len = match crate::ov_embed::model_seq_len(name) {
+                Some(s) => s,
+                None => {
+                    eprintln!(
+                        "[panda] OV bypass: no NPU seq_len for {name}; CPU fallback"
+                    );
+                    return None;
+                }
+            };
+            match crate::ov_embed::OvEmbedder::try_new(&onnx, &tok, seq_len) {
+                Ok(e) => {
+                    eprintln!("[panda] embedder: {} on NPU (raw OpenVINO)", name);
+                    Some(e)
+                }
+                Err(err) => {
+                    eprintln!("[panda] OV bypass init failed: {err}");
+                    None
+                }
+            }
+        })
+        .as_ref()
+}
+
+/// Eagerly construct the OV embedder. Used by `panda daemon start` so the
+/// multi-second NPU compile happens once at start, not on the first client
+/// embed call.
+///
+/// Returns `Some(())` on success, `None` if construction failed (in which
+/// case `OV_EMBEDDER` is cached as `None` and subsequent calls go to CPU).
+#[cfg(feature = "openvino")]
+pub fn preload_ov_embedder() -> Option<()> {
+    get_ov_embedder().map(|_| ())
+}
+
+/// Reports whether the OV embedder is currently active. Used by the smoke
+/// test to assert NPU was actually engaged (vs silent CPU fallback).
+#[cfg(feature = "openvino")]
+pub fn ov_embedder_is_active() -> bool {
+    OV_EMBEDDER.get().and_then(|o| o.as_ref()).is_some()
+}
+```
+
+- [ ] **Step 3: Build with feature off**
+
+Run:
+```bash
+cargo build -p panda-core
+```
+Expected: clean build. None of the new symbols compile (all `#[cfg]`-gated).
+
+- [ ] **Step 4: Build with feature on**
+
+Run:
+```bash
+cargo build -p panda-core --features openvino 2>&1 | tail -10
+```
+Expected: clean compile. Warnings about unused `get_ov_embedder` / `preload_ov_embedder` / `ov_embedder_is_active` are expected — Task 5 wires them up.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ccr-core/src/summarizer.rs
+git commit -m "feat(ccr-core): add OV_EMBEDDER static and accessors" -m "Lazy and eager construction APIs for the raw OpenVINO embedder, mirroring the existing MODEL_CACHE pattern. ov_embedder_is_active is exposed for the smoke test so NPU engagement can be asserted (not just configured)." -m "Not yet wired into embed_and_normalize — that's the next commit."
+```
+
+---
+
+## Task 5: Wire OV dispatch into `embed_and_normalize` and `embed_direct`
+
+**Files:**
+- Modify: `ccr-core/src/summarizer.rs`
+
+- [ ] **Step 1: Update `embed_and_normalize`**
+
+Find the existing function:
+
+```rust
+fn embed_and_normalize(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
+    #[cfg(unix)]
+    if let Some(embeddings) = crate::embed_client::daemon_embed(&texts, true) {
+        return Ok(embeddings);
+    }
+    #[cfg(unix)]
+    apply_nice_once();
+    embed_direct(texts)
+}
+```
+
+Replace with:
+
+```rust
+fn embed_and_normalize(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
+    #[cfg(unix)]
+    if let Some(embeddings) = crate::embed_client::daemon_embed(&texts, true) {
+        return Ok(embeddings);
+    }
+    #[cfg(feature = "openvino")]
+    if current_ep() == "npu" {
+        if let Some(ov) = get_ov_embedder() {
+            let texts_slice: Vec<&str> = texts.iter().copied().collect();
+            let mut v = ov.embed(&texts_slice)?;
+            for e in &mut v {
+                l2_normalize(e);
+            }
+            return Ok(v);
+        }
+    }
+    #[cfg(unix)]
+    apply_nice_once();
+    embed_direct(texts)
+}
+```
+
+(`OvEmbedder::embed` already L2-normalises internally; we re-normalise here defensively to keep the contract identical to `embed_direct`'s output. Leave the duplicate normalise in — it's idempotent on already-unit vectors and removes a subtle "is this normalised" question for future readers.)
+
+- [ ] **Step 2: Update `embed_direct` so the daemon worker thread also tries OV**
+
+`embed_direct` is what the daemon's worker calls (the daemon doesn't go through `embed_and_normalize`; it calls a public function directly). Find:
+
+```rust
+pub fn embed_direct(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
+    let model = get_model()?;
+    let mut embeddings = model.embed(&texts)?;
+    for emb in &mut embeddings {
+        l2_normalize(emb);
+    }
+    Ok(embeddings)
+}
+```
+
+Replace with:
+
+```rust
+pub fn embed_direct(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
+    #[cfg(feature = "openvino")]
+    if current_ep() == "npu" {
+        if let Some(ov) = get_ov_embedder() {
+            let texts_slice: Vec<&str> = texts.iter().copied().collect();
+            let mut v = ov.embed(&texts_slice)?;
+            for e in &mut v {
+                l2_normalize(e);
+            }
+            return Ok(v);
+        }
+    }
+    let model = get_model()?;
+    let mut embeddings = model.embed(&texts)?;
+    for emb in &mut embeddings {
+        l2_normalize(emb);
+    }
+    Ok(embeddings)
+}
+```
+
+- [ ] **Step 3: Add the CPU "embedder loaded" log to `get_model`**
+
+The Approach A eprintln moved out of `MiniLmEmbedder::new` in Task 1. We add it back in `get_model`'s init closure so it fires once when ORT actually loads. Find:
+
+```rust
+fn get_model() -> anyhow::Result<&'static MiniLmEmbedder> {
+    MODEL_CACHE.get_or_try_init(|| {
+        let name = get_model_name();
+        if !bert_is_cached(name) {
+            eprintln!("[panda] downloading BERT model ({name}, one-time setup)...");
+            eprintln!("[panda] this may take a minute. future runs are instant.");
+        }
+        let embedder = MiniLmEmbedder::new(name)?;
+        mark_bert_cached(name);
+        Ok(embedder)
+    })
+}
+```
+
+Replace with:
+
+```rust
+fn get_model() -> anyhow::Result<&'static MiniLmEmbedder> {
+    MODEL_CACHE.get_or_try_init(|| {
+        let name = get_model_name();
+        if !bert_is_cached(name) {
+            eprintln!("[panda] downloading BERT model ({name}, one-time setup)...");
+            eprintln!("[panda] this may take a minute. future runs are instant.");
+        }
+        let embedder = MiniLmEmbedder::new(name)?;
+        mark_bert_cached(name);
+        eprintln!("[panda] embedder: {} on CPU (ort)", name);
+        Ok(embedder)
+    })
+}
+```
+
+- [ ] **Step 4: Make `current_ep` `pub` so the daemon crate can call it**
+
+Find the existing function:
+
+```rust
+pub(crate) fn current_ep() -> &'static str {
+```
+
+Change to:
+
+```rust
+pub fn current_ep() -> &'static str {
+```
+
+- [ ] **Step 5: Default build**
+
+Run:
+```bash
+cargo build -p panda-core
+```
+Expected: clean. The `#[cfg(feature = "openvino")]` blocks are absent; only the `[panda] embedder: ... on CPU (ort)` line is added unconditionally — that's intended (CPU is what runs in default builds).
+
+- [ ] **Step 6: Feature-on build**
+
+Run:
+```bash
+cargo build -p panda-core --features openvino 2>&1 | tail -10
+```
+Expected: clean.
+
+- [ ] **Step 7: Workspace build**
+
+Run:
+```bash
+cargo build
+```
+Expected: clean.
+
+- [ ] **Step 8: Tests**
+
+Run:
+```bash
+cargo test -p panda-core
+```
+Expected: all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add ccr-core/src/summarizer.rs
+git commit -m "feat(ccr-core): wire OV embedder ahead of ORT-CPU in dispatch path" -m "embed_and_normalize and embed_direct both try the OV embedder first when --features openvino is on AND current_ep() == 'npu'. Falls through to ORT-CPU on any failure (including the first call after mark_degraded)." -m "Also moves the CPU 'embedder loaded' log into get_model's init closure so it only fires when ORT actually constructs a session — fixes Approach A's false-NPU log bug. current_ep is promoted from pub(crate) to pub for the daemon's eager-preload call (next commit)."
+```
+
+---
+
+## Task 6: Eager OV preload in the daemon
+
+**Files:**
+- Modify: `ccr/src/cmd/daemon.rs`
+
+- [ ] **Step 1: Locate the existing setter calls**
+
+Run:
+```bash
+grep -n "set_execution_provider\|preload_model" ccr/src/cmd/daemon.rs
+```
+Expected: a line near `daemon_main` calling `set_execution_provider`, followed by `preload_model().is_err()`.
+
+- [ ] **Step 2: Add the eager preload between `set_execution_provider` and `preload_model`**
+
+Open `ccr/src/cmd/daemon.rs`. Find:
+
+```rust
+        panda_core::summarizer::set_model_name(&config.global.bert_model);
+        panda_core::summarizer::set_ort_threads(config.global.ort_threads);
+        panda_core::summarizer::set_execution_provider(&config.global.execution_provider);
+    }
+    if panda_core::summarizer::preload_model().is_err() {
+        std::process::exit(1);
+    }
+```
+
+Replace with:
+
+```rust
+        panda_core::summarizer::set_model_name(&config.global.bert_model);
+        panda_core::summarizer::set_ort_threads(config.global.ort_threads);
+        panda_core::summarizer::set_execution_provider(&config.global.execution_provider);
+    }
+    #[cfg(feature = "openvino")]
+    if panda_core::summarizer::current_ep() == "npu" {
+        // Eagerly compile the model for NPU so the multi-second cost is
+        // paid here instead of on the first client embed call. If init
+        // fails the OV_EMBEDDER static caches None and subsequent calls
+        // go to CPU automatically.
+        let _ = panda_core::summarizer::preload_ov_embedder();
+    }
+    if panda_core::summarizer::preload_model().is_err() {
+        std::process::exit(1);
+    }
+```
+
+We always preload the CPU embedder too — it's the fallback path and costs ~100ms.
+
+- [ ] **Step 3: Default build**
+
+Run:
+```bash
+cargo build -p panda
+```
+Expected: clean.
+
+- [ ] **Step 4: Feature-on build**
+
+Run:
+```bash
+cargo build -p panda --features openvino 2>&1 | tail -5
+```
+Expected: clean.
+
+- [ ] **Step 5: Tests**
+
+Run:
+```bash
+cargo test
+```
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ccr/src/cmd/daemon.rs
+git commit -m "feat(ccr): eagerly preload OV embedder in daemon when configured" -m "When the binary is built with --features openvino and the resolver picks NPU, the daemon now triggers OvEmbedder::try_new during start (after set_*, before bind). Multi-second NPU compile happens once at daemon-start, not on the first client embed call." -m "Init failure caches None in OV_EMBEDDER and embeds transparently fall to CPU."
+```
+
+---
+
+## Task 7: Unit tests for `ov_embed.rs`
+
+**Files:**
+- Modify: `ccr-core/src/ov_embed.rs`
+
+These run on every CI machine — no openvino-sys initialization, no NPU touched. Tests live at the bottom of `ov_embed.rs` in a `#[cfg(test)] mod tests` block. The whole file is already gated on `#[cfg(feature = "openvino")]` via `lib.rs`, so the tests only run with `--features openvino`.
+
+- [ ] **Step 1: Append the test module**
+
+Open `ccr-core/src/ov_embed.rs`. At the very end of the file (after the last closing brace of `impl OvEmbedder`), append:
+
+```rust
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // env tests share process state — serialize them.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear_env() {
+        std::env::remove_var("OPENVINO_LIB_PATH");
+    }
+
+    #[test]
+    fn ov_lib_path_returns_none_when_nothing_present() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_env();
+        let tmp = tempfile::tempdir().unwrap();
+        let saved_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", tmp.path());
+        let result = ov_lib_path();
+        if let Some(home) = saved_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        // Result depends on whether /usr/lib/... has libopenvino_c.so on the
+        // host. If yes, that's also valid — just assert no panic.
+        let _ = result;
+    }
+
+    #[test]
+    fn ov_lib_path_honours_env_file() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("libopenvino_c.so");
+        std::fs::write(&path, b"stub").unwrap();
+        std::env::set_var("OPENVINO_LIB_PATH", &path);
+        let resolved = ov_lib_path();
+        std::env::remove_var("OPENVINO_LIB_PATH");
+        assert_eq!(resolved.as_deref(), Some(path.as_path()));
+    }
+
+    #[test]
+    fn ov_lib_path_honours_env_dir() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = tmp.path().join("libopenvino_c.so");
+        std::fs::write(&lib, b"stub").unwrap();
+        std::env::set_var("OPENVINO_LIB_PATH", tmp.path());
+        let resolved = ov_lib_path();
+        std::env::remove_var("OPENVINO_LIB_PATH");
+        assert_eq!(resolved.as_deref(), Some(lib.as_path()));
+    }
+
+    #[test]
+    fn model_seq_len_returns_known_models() {
+        assert_eq!(model_seq_len("AllMiniLML6V2"), Some(128));
+        assert_eq!(model_seq_len("AllMiniLML12V2"), Some(128));
+        assert_eq!(model_seq_len("nonsense"), None);
+        assert_eq!(model_seq_len(""), None);
+    }
+
+    #[test]
+    fn is_degraded_starts_false_marks_true_idempotent() {
+        // Note: DEGRADED is a process-wide flag. This test must run before
+        // any other test in this file would call mark_degraded — currently
+        // none do, so we're safe. Ordering caveat noted.
+        assert!(!is_degraded(), "DEGRADED should start clear");
+        mark_degraded("test-1");
+        assert!(is_degraded(), "DEGRADED should be set after first call");
+        mark_degraded("test-2"); // Should not panic, should not double-print
+        assert!(is_degraded());
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run:
+```bash
+cargo test -p panda-core --features openvino ov_embed::tests
+```
+Expected: 5 tests pass. Output similar to:
+```
+running 5 tests
+test ov_embed::tests::is_degraded_starts_false_marks_true_idempotent ... ok
+test ov_embed::tests::model_seq_len_returns_known_models ... ok
+test ov_embed::tests::ov_lib_path_honours_env_dir ... ok
+test ov_embed::tests::ov_lib_path_honours_env_file ... ok
+test ov_embed::tests::ov_lib_path_returns_none_when_nothing_present ... ok
+test result: ok. 5 passed; 0 failed
+```
+
+- [ ] **Step 3: Run the full feature-on test suite**
+
+Run:
+```bash
+cargo test -p panda-core --features openvino
+```
+Expected: all green, including the existing `ep_resolver_tests` and `execution_provider_tests` from Approach A.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ccr-core/src/ov_embed.rs
+git commit -m "test(ccr-core): unit tests for ov_embed pure functions" -m "Five tests covering ov_lib_path resolution (env unset, env-file form, env-dir form), model_seq_len lookup, and the DEGRADED flag's idempotence. None touch openvino-sys or NPU." -m "ENV_LOCK Mutex serialises tests that mutate process env, so cargo's default parallel test runner doesn't race them."
+```
+
+---
+
+## Task 8: Sharper assertions in `npu_smoke.rs`
+
+**Files:**
+- Modify: `ccr-core/tests/npu_smoke.rs`
+
+Approach A's smoke test passed even when CPU silently ran. This task replaces the assertions with `ov_embedder_is_active()` checks that cannot pass without the OV embedder.
+
+- [ ] **Step 1: Read the current file to confirm it exists**
+
+Run:
+```bash
+cat ccr-core/tests/npu_smoke.rs
+```
+Expected: the file from Approach A's Task 6 — two tests `npu_smoke_embeds_three_strings` and `npu_falls_back_to_cpu_when_openvino_missing`.
+
+- [ ] **Step 2: Replace the file content**
+
+Overwrite `ccr-core/tests/npu_smoke.rs` with:
+
+```rust
+//! Feature-gated NPU smoke test.
+//!
+//! Skipped at compile time unless `--features openvino`; skipped at run time
+//! unless `OPENVINO_NPU_AVAILABLE=1`. Verifies the raw OpenVINO embedder
+//! actually engaged (asserts `ov_embedder_is_active()`), not just that some
+//! embedder produced 384-dim L2-normalised vectors.
+
+#![cfg(feature = "openvino")]
+
+use panda_core::summarizer;
+
+fn npu_opted_in() -> bool {
+    std::env::var("OPENVINO_NPU_AVAILABLE").ok().as_deref() == Some("1")
+}
+
+#[test]
+fn npu_smoke_actually_uses_npu() {
+    if !npu_opted_in() {
+        eprintln!("skipping: OPENVINO_NPU_AVAILABLE != 1");
+        return;
+    }
+    summarizer::set_execution_provider("npu");
+    let texts = vec!["error: build failed", "warning: deprecated", "ok"];
+
+    let t0 = std::time::Instant::now();
+    let embeddings = summarizer::embed_direct(texts).expect("embed_direct");
+    let elapsed = t0.elapsed();
+
+    assert_eq!(embeddings.len(), 3, "expected 3 vectors");
+    for (i, v) in embeddings.iter().enumerate() {
+        assert_eq!(v.len(), 384, "vec {i} dim mismatch");
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!(
+            (norm - 1.0).abs() < 1e-3,
+            "vec {i} not L2-normalised: norm={norm}"
+        );
+    }
+
+    assert!(
+        summarizer::ov_embedder_is_active(),
+        "raw OV embedder must be active in NPU mode — without this assertion, \
+         a silent CPU fallback would let this test pass spuriously"
+    );
+
+    eprintln!("npu embed elapsed: {elapsed:?}");
+}
+
+#[test]
+fn npu_falls_back_to_cpu_when_libopenvino_missing() {
+    if !npu_opted_in() {
+        eprintln!("skipping: OPENVINO_NPU_AVAILABLE != 1");
+        return;
+    }
+    // Hide libopenvino_c.so so OvEmbedder::try_new fails. ov_lib_path()
+    // checks OPENVINO_LIB_PATH first, so pointing it at /dev/null beats
+    // any other path on the host.
+    std::env::set_var("OPENVINO_LIB_PATH", "/dev/null");
+    summarizer::set_execution_provider("npu");
+
+    // Embedding should still succeed via CPU fallback.
+    let r = summarizer::embed_direct(vec!["x"]);
+    std::env::remove_var("OPENVINO_LIB_PATH");
+
+    assert!(r.is_ok(), "expected CPU fallback to succeed: {:?}", r.err());
+    assert!(
+        !summarizer::ov_embedder_is_active(),
+        "OV embedder must NOT be active when libopenvino is hidden"
+    );
+}
+```
+
+Note: this test file is independent of Task 7's unit tests — they test pure functions in `ov_embed`; this exercises the full embedder construction path against real NPU.
+
+- [ ] **Step 3: Run the smoke test (skipped without env var)**
+
+Run:
+```bash
+cargo test -p panda-core --features openvino --test npu_smoke
+```
+Expected: both tests run and skip silently with `skipping: OPENVINO_NPU_AVAILABLE != 1`. Both pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ccr-core/tests/npu_smoke.rs
+git commit -m "test(ccr-core): assert ov_embedder_is_active in NPU smoke test" -m "Approach A's assertions (3 vectors, 384 dim, L2-normalised) all hold whether NPU or CPU ran the inference, so the test passed even when OpenVINO EP silently failed to engage. Now we additionally assert summarizer::ov_embedder_is_active() — only true when OvEmbedder::try_new succeeded. Catches false-NPU regressions." -m "Skipped silently unless OPENVINO_NPU_AVAILABLE=1, same as before."
+```
+
+---
+
+## Task 9: Rewrite README NPU section
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Locate the existing section**
+
+Run:
+```bash
+grep -n "## NPU support" README.md
+```
+Expected: a line number for the existing "NPU support (opt-in, Intel only)" header from Approach A's Task 7.
+
+- [ ] **Step 2: Replace the entire section**
+
+Open `README.md`. Find the section starting with `## NPU support (opt-in, Intel only)` and ending just before the next `---` divider. Replace the whole block (header through the line before the divider) with:
+
+```markdown
+## NPU support (opt-in, Intel only)
+
+Panda's embedding model can run on an Intel NPU (e.g. Meteor Lake NPU 3720)
+through a direct OpenVINO C-API embedder that bypasses ONNX Runtime entirely.
+This is opt-in.
+
+### Build
+
+```bash
+cargo build --release --features openvino
+```
+
+The build links against `openvino`/`openvino-sys` (intel/openvino-rs) with
+`runtime-linking`, so no OpenVINO library is required at link time. At
+runtime, panda dlopens `libopenvino_c.so` from the first of:
+
+1. `$OPENVINO_LIB_PATH` (if set; can be a file path or a directory).
+2. `~/.local/share/ccr/onnxruntime/libopenvino_c.so`.
+3. `/usr/lib/x86_64-linux-gnu/libopenvino_c.so`, `/usr/local/lib/...`,
+   `/opt/intel/openvino/runtime/lib/intel64/...`.
+
+Install OpenVINO 2024+ runtime via your distro's package manager or Intel's
+installer.
+
+### Configure
+
+In `panda.toml` (project or `~/.config/panda/config.toml`):
+
+```toml
+[global]
+execution_provider = "npu"   # "auto" | "cpu" | "npu"
+```
+
+Or override at runtime:
+
+```bash
+PANDA_NPU=npu panda daemon start    # force NPU for this daemon
+PANDA_NPU=cpu panda run cargo build # force CPU for this invocation
+```
+
+### How it works
+
+The first call pays a one-time NPU compile cost (~3–10 s on NPU 3720). The
+compiled blob is persisted to `~/.cache/panda/openvino/` — subsequent starts
+warm up in <500 ms. Run `panda daemon start` once at the beginning of a
+session and every embedding is sub-millisecond dispatch overhead from the
+warm InferRequest pool (size matches the NPU's reported optimal request
+count, typically 4 on Meteor Lake's two-tile NPU 3720).
+
+If NPU initialisation or inference fails, panda logs one line on stderr and
+falls back to CPU for the rest of the process — the daemon doesn't crash.
+To make these failures fatal (useful when diagnosing whether NPU is actually
+in use), set `PANDA_NPU_STRICT=1`. To force a specific inference precision,
+set `PANDA_NPU_PRECISION=FP16` or `=FP32`.
+```
+
+- [ ] **Step 3: Verify the section renders cleanly**
+
+Run:
+```bash
+grep -nA3 "## NPU support" README.md | head -20
+```
+Expected: the new section header followed by the new opening paragraph.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: rewrite NPU section for the raw OpenVINO bypass" -m "Approach A's section described the ort/openvino EP path. The bypass uses openvino-rs directly with a different runtime story: runtime-linking (no link-time deps), library finder, ~/.cache/panda/openvino blob cache, async pool. Adds notes on PANDA_NPU_STRICT and PANDA_NPU_PRECISION envs."
+```
+
+---
+
+## Task 10: Manual verification
+
+**Files:** none — exercises the binaries.
+
+- [ ] **Step 1: Default build clean**
+
+Run:
+```bash
+cargo build --release -p panda
+./target/release/panda run ls 2>&1 | tail -10
+```
+Expected: clean build, normal `ls` output. Stderr (if BERT triggers) shows `[panda] embedder: AllMiniLML6V2 on CPU (ort)`. Default behaviour unchanged.
+
+- [ ] **Step 2: Feature-on build clean**
+
+Run:
+```bash
+cargo build --release -p panda --features openvino
+ldd ./target/release/panda 2>&1 | grep -iE "openvino|onnx" || echo "(no dynamic OV/ONNX deps — runtime-linking working)"
+```
+Expected: clean build. The `ldd` should show no openvino libs (runtime-linking pulls them in via dlopen, not link-time).
+
+- [ ] **Step 3: Whole-workspace tests, both feature configs**
+
+Run:
+```bash
+cargo test
+cargo test --features openvino
+```
+Expected: both green. Smoke tests skip without `OPENVINO_NPU_AVAILABLE`.
+
+- [ ] **Step 4: NPU smoke test on real hardware**
+
+Run:
+```bash
+OPENVINO_NPU_AVAILABLE=1 cargo test -p panda-core --features openvino --test npu_smoke -- --nocapture
+```
+Expected: both tests pass. First run prints multi-second elapsed (cold compile or cache miss); a second invocation prints sub-second (warm cache hit).
+
+If `npu_smoke_actually_uses_npu` fails — that's the empirical signal that the OV bypass itself doesn't engage on this machine. STOP and report; this is the spec's escalation trigger.
+
+- [ ] **Step 5: Daemon on NPU**
+
+Edit `panda.toml` (in the worktree) to set `execution_provider = "npu"`, then:
+
+```bash
+./target/release/panda daemon stop 2>/dev/null
+./target/release/panda daemon start
+sleep 12
+./target/release/panda daemon status
+echo "warning\nerror\nok\nok\nok\nok\nok\nok\nok\nok\nok\nok\nok\nok\nok" | ./target/release/panda filter --command cargo
+```
+Expected: daemon up. The `panda filter` invocation triggers an embed; stderr should show `[panda] embedder: AllMiniLML6V2 on NPU (raw OpenVINO)` exactly once per process.
+
+- [ ] **Step 6: Strict mode fails loud**
+
+Run:
+```bash
+./target/release/panda daemon stop
+OPENVINO_LIB_PATH=/dev/null PANDA_NPU=npu PANDA_NPU_STRICT=1 ./target/release/panda daemon start
+sleep 2
+./target/release/panda daemon status
+```
+Expected: `daemon status` reports it's NOT running, OR if it's running, `panda run cargo build` returns an error rather than CPU output. Reset by running `panda daemon stop` and unsetting the envs.
+
+- [ ] **Step 7: Real workload latency**
+
+Run:
+```bash
+./target/release/panda daemon stop
+./target/release/panda daemon start    # NPU mode per panda.toml
+time ./target/release/panda run cargo build -p panda-core 2>&1 | tail -5
+time ./target/release/panda run cargo build -p panda-core 2>&1 | tail -5  # warm
+```
+Expected: clean filtered output, no `NPU embedder failed` lines. Comparable savings vs CPU baseline (NPU is for speed, not quality).
+
+- [ ] **Step 8: Push and open PR**
+
+```bash
+git push -u origin feat/npu-on-ort
+gh pr create --base main --title "feat: NPU support via raw OpenVINO bypass" --body-file - <<'EOF'
+Restores Intel NPU acceleration on top of upstream/main (post ort-migration)
+by porting the archived ov_embed.rs forward and wiring it into the resolver/
+daemon scaffolding from the earlier ORT-EP attempt.
+
+Specs:
+- docs/superpowers/specs/2026-05-01-npu-on-upstream-ort-design.md
+- docs/superpowers/specs/2026-05-01-npu-raw-openvino-bypass-design.md
+Plans:
+- docs/superpowers/plans/2026-05-01-npu-on-ort.md
+- docs/superpowers/plans/2026-05-01-npu-raw-openvino-bypass.md
+
+Why the bypass: ort 2.0.0-rc.12's OpenVINO EP cannot engage on Meteor Lake
+(libonnxruntime ABI clash with the OpenVINO provider plugins, plus an
+unrelated `load-dynamic` compile error). Empirical verification on the
+target hardware showed the EP path silently falls back to CPU while
+logging "on NPU" — bug, not a feature. The bypass uses the openvino-rs
+crates directly, the same path the fork shipped before the upstream merge.
+
+Default builds are byte-identical to upstream — no behaviour change for
+users who don't pass `--features openvino`.
+EOF
+```
+Expected: PR opened. Link printed by `gh`.
+
+---
+
+## Self-review notes
+
+Spec coverage:
+- `[features] openvino` repointed — Task 2 ✓
+- `ov_embed.rs` port + `model_seq_len` + `ov_lib_path` pub + drop `find_fastembed_onnx` — Task 3 ✓
+- Module decl in `lib.rs` — Task 3 ✓
+- `OV_EMBEDDER` static + `get_ov_embedder` + `preload_ov_embedder` + `ov_embedder_is_active` — Task 4 ✓
+- Dispatch into `embed_and_normalize` and `embed_direct` — Task 5 ✓
+- CPU log moved into `MODEL_CACHE.get_or_try_init` — Task 5 ✓
+- `current_ep` made `pub` — Task 5 ✓
+- `MiniLmEmbedder::new` reverted — Task 1 ✓
+- Daemon eager preload — Task 6 ✓
+- Unit tests (5 in `ov_embed`) — Task 7 ✓
+- Sharper smoke tests with `ov_embedder_is_active` — Task 8 ✓
+- README rewrite — Task 9 ✓
+- Manual verification + PR — Task 10 ✓
+
+Type/name consistency:
+- `OvEmbedder::try_new(onnx_path: &Path, tokenizer_path: &Path, seq_len: usize)` — used identically in `get_ov_embedder` and the spec.
+- `model_seq_len(&str) -> Option<usize>` — used identically across Task 3, Task 4, and Task 7.
+- `current_ep() -> &'static str` — visibility upgrade covered explicitly in Task 5.
+- `ov_embedder_is_active() -> bool` — defined Task 4, used Task 8.
+- `preload_ov_embedder() -> Option<()>` — defined Task 4, called Task 6.
+- The four `#[cfg(feature = "openvino")]` spots in `summarizer.rs` are: the static, `get_ov_embedder`/`preload_ov_embedder`/`ov_embedder_is_active` (one cfg per fn), the dispatch in `embed_and_normalize`, the dispatch in `embed_direct`. Total: 6 cfg guards across one logical surface — concentrated, not scattered.
+
+No placeholders, no "implement later", no "similar to Task N". Every code step shows the actual code; every command step shows the exact command and expected output.

--- a/docs/superpowers/specs/2026-05-01-npu-on-upstream-ort-design.md
+++ b/docs/superpowers/specs/2026-05-01-npu-on-upstream-ort-design.md
@@ -1,0 +1,185 @@
+# NPU support on upstream ORT-based panda — design
+
+**Date:** 2026-05-01
+**Status:** Draft for review
+**Branch (target):** `feat/npu-on-ort` cut from `upstream/main` @ `9546fb6` (v1.3.9)
+
+## Problem
+
+Upstream landed PR #5 ("ort-migration") which:
+
+- Replaces `fastembed` with direct `ort` 2.0.0-rc.12 for ONNX inference.
+- Deletes `ccr-core/src/ov_embed.rs` (the fork's OpenVINO/NPU bypass, ~400 lines).
+- Rewrites `ccr-core/src/summarizer.rs` around a new `MiniLmEmbedder` struct.
+- Adds an embedding daemon (`panda daemon start/stop/status`) over a Unix socket.
+
+The fork's NPU acceleration on Intel Meteor Lake (NPU 3720) is built on the deleted code. After this work, `main` should be back on upstream and NPU acceleration restored as a small, opt-in graft on top of the new ORT-based code.
+
+## Non-goals
+
+- Restoring the 9 opt-in embedding models (Snowflake, Jina, Nomic, BGE family). Separate follow-up.
+- Restoring `embed-bench` and `bench_summarize`. Separate follow-up.
+- A raw-OpenVINO bypass alongside ORT (the deleted `ov_embed.rs` design). Only revisited if the ORT OpenVINO EP empirically fails on a model we care about.
+- GPU support. The toggle is `cpu`/`npu`/`auto`; GPU is a one-line extension if/when needed.
+- Restoring `install.sh`. NPU users install the OpenVINO runtime once out-of-band.
+
+## Approach (chosen — "minimal-conflict rebase + thin NPU graft")
+
+1. Reset the fork's `main` to `upstream/main`. Preserve the fork's pre-merge custom commits on `archive/pre-upstream-merge` for later cherry-picking.
+2. Cut `feat/npu-on-ort` from the new `main` in an isolated worktree at `.worktrees/npu-on-ort`.
+3. Add NPU support as a small patch series on the new code, using `ort`'s built-in OpenVINO execution provider (`ort` feature `openvino`) — no separate inference engine.
+
+Rejected alternatives:
+- **Hand-merge `upstream/main` into the fork's existing `main`.** Conflict surface ≈ 700 lines in `summarizer.rs` plus deleted files; effectively a rewrite, high risk.
+- **Restore raw OpenVINO bypass alongside ORT.** Two embedder code paths to maintain through future upstream merges; only justified if the ORT EP path fails empirically.
+
+## Architecture
+
+```
+panda CLI (hook/run/filter)
+  │
+  ├── embed_and_normalize(texts)
+  │     ├── 1st: try daemon_embed via /run/user/$UID/panda/embed.sock  ← daemon owns NPU session
+  │     └── fallback: in-process MiniLmEmbedder
+  │
+  └── panda daemon start
+        └── daemon_main → preload_model → MiniLmEmbedder::new(name)
+                                                          │
+                                                          ▼
+                                       ort::Session::builder()
+                                         .with_execution_providers([
+                                            (cfg) OpenVINO::default()
+                                                  .with_device_type("NPU").build(),
+                                            CPU::default().build(),  // always last
+                                         ])
+```
+
+Single integration point: the EP list passed to `Session::builder().with_execution_providers(...)` inside `MiniLmEmbedder::new`. CPU is always the final EP so ORT's per-op fallthrough handles ops the OpenVINO EP can't compile.
+
+## File-level changes
+
+### `ccr-core/Cargo.toml`
+
+Add an opt-in feature:
+
+```toml
+[features]
+default = []
+openvino = ["ort/openvino"]
+```
+
+No change to default deps. NPU users build with `cargo build --release --features openvino`.
+
+### `ccr-core/src/config.rs`
+
+Restore one field on `GlobalConfig`:
+
+```rust
+#[serde(default = "default_execution_provider")]
+pub execution_provider: String,  // "auto" | "cpu" | "npu"
+```
+
+`default_execution_provider() -> "auto"`. `"auto"` resolves at runtime to `"npu"` if the `openvino` feature is compiled in, else `"cpu"`.
+
+### `ccr-core/src/summarizer.rs`
+
+Three additions, each mirroring an existing pattern:
+
+- `static EXECUTION_PROVIDER: OnceCell<String>` and `pub fn set_execution_provider(s: &str)` — same shape as `set_model_name` / `set_ort_threads`.
+- A private `ep_choice() -> &'static str` resolver that reads `EXECUTION_PROVIDER`, applies the `PANDA_NPU` env override, validates the value (unknown → fall back to `"auto"` with a one-time warning), and resolves `"auto"`.
+- In `MiniLmEmbedder::new`, build the EP list conditionally:
+
+  ```rust
+  let mut eps: Vec<ort::ep::ExecutionProviderDispatch> = Vec::new();
+  #[cfg(feature = "openvino")]
+  if matches!(ep_choice(), "npu") {
+      eps.push(ort::ep::OpenVINO::default()
+          .with_device_type("NPU")
+          .build().into());
+  }
+  eps.push(ort::ep::CPU::default().with_arena_allocator(false).build().into());
+  builder = builder.with_execution_providers(eps).map_err(ort_err)?;
+  ```
+
+  On EP-list failure, retry once with `[CPU]` only (unless `PANDA_NPU_STRICT=1`). The retry must rebuild the `Session::builder()` from scratch because ORT builders are consumed by `with_execution_providers`.
+
+### `ccr/src/cmd/daemon.rs`
+
+In `daemon_main`, next to the existing `set_model_name` / `set_ort_threads` calls:
+
+```rust
+panda_core::summarizer::set_execution_provider(&config.global.execution_provider);
+```
+
+The daemon now preloads an NPU-compiled session once on start. The OpenVINO compile cost (~3-10s on first run, cached on disk by OpenVINO) is paid by the daemon, not by foreground hooks.
+
+### `ccr/src/main.rs` (and any non-daemon init paths)
+
+Same `set_execution_provider` call after config load, so the in-process fallback path also honours config.
+
+### `README.md`
+
+Short "NPU support (opt-in)" section: `cargo build --release --features openvino`, requires `libopenvino_c.so` discoverable at runtime, set `execution_provider = "npu"` in `panda.toml` or `PANDA_NPU=npu`.
+
+## Data flow
+
+**Cold-start (daemon, NPU):** `panda daemon start` → double-fork → flock pid → load config → `set_*` → `preload_model` → `MiniLmEmbedder::new` → ORT loads `libopenvino_c.so`, OpenVINO compiles MiniLM ONNX for NPU 3720 (~3-10s, disk-cached) → bind socket → accept loop. Subsequent `daemon_embed` calls reuse the warm NPU session.
+
+**Cold-start (in-process, NPU):** Same flow inside the foreground `panda` process. Compile cost paid on the first hook invocation that reaches the BERT stage. Subsequent processes hit the OpenVINO disk cache and warm up in <1s.
+
+## Error handling
+
+| Failure | Where | Behaviour |
+|---|---|---|
+| Built without `--features openvino`, config says `"npu"` | Compile time — feature-gated block absent; `ep_choice()` returns `"cpu"` | One-time `eprintln!`: `[panda] execution_provider=npu but binary built without openvino feature; using CPU` |
+| Built with feature, `libopenvino_c.so` missing at runtime | `Session::builder().with_execution_providers(...)` returns `ort::Error` | Log `[panda] OpenVINO EP unavailable: <err>; falling back to CPU`, rebuild builder, retry with `[CPU]` |
+| OpenVINO compiles but NPU device absent / busy | `with_execution_providers` or first `session.run()` | Same fallback path; ORT per-op fallback hides most cases |
+| `PANDA_NPU_STRICT=1` set | Disables silent fallbacks above | Surface the error, fail loud |
+| Daemon crashes mid-embed | `daemon_embed()` returns `None` | `embed_and_normalize` already falls through to `embed_direct`. Next hook re-runs `try_auto_start`; daemon restarts fresh |
+
+**Design choices flagged:**
+
+- CPU is always the last EP. Free graceful degradation per-op without extra code.
+- No multi-device retry logic. `"auto"` means "NPU if compiled in, else CPU" — not "try GPU then NPU then CPU."
+
+**Observability:** one `eprintln!` on session creation: `[panda] embedder: <model> on <NPU|CPU>`. Visible in daemon log / journal, and in foreground runs.
+
+## Testing
+
+### Unit tests (`ccr-core/src/summarizer.rs`)
+
+1. `ep_choice_resolves_auto_to_cpu_without_feature` — feature off → `"cpu"` regardless of config.
+2. `ep_choice_honours_panda_npu_env` — `PANDA_NPU=cpu` overrides `"npu"` and vice versa.
+3. `ep_choice_validates_unknown_string` — unknown value → `"auto"` with warning, never panics.
+
+These run on every CI machine; they don't touch ORT.
+
+### Feature-gated integration test (`ccr-core/tests/npu_smoke.rs`, `#[cfg(feature = "openvino")]`)
+
+4. `npu_smoke_embeds_three_strings` — `MiniLmEmbedder` with `"npu"`, embed `["error", "warning", "ok"]`, assert shape 3×384 and L2-normalised. Skipped silently unless `OPENVINO_NPU_AVAILABLE=1`.
+5. `npu_falls_back_to_cpu_when_libopenvino_missing` — hide OV runtime, expect embedder construction to succeed via CPU-only retry.
+
+### Manual verification checklist
+
+- [ ] `cargo build --release` (no feature) builds clean; `panda run ls` works.
+- [ ] `cargo build --release --features openvino` builds clean; `panda run ls` works.
+- [ ] `cargo test -p panda-core` passes.
+- [ ] `cargo test -p panda-core --features openvino` passes (or skips NPU tests cleanly without `OPENVINO_NPU_AVAILABLE`).
+- [ ] `panda daemon start` with `execution_provider="npu"` — daemon comes up, log shows `embedder: AllMiniLML6V2 on NPU`, no errors.
+- [ ] First-call latency bounded (<15s); subsequent calls <50ms for ~10 lines.
+- [ ] Restart daemon with NPU disabled → log shows `on CPU`. Toggle confirmed.
+- [ ] `PANDA_NPU_STRICT=1 panda daemon start` with OV runtime hidden → fails loud.
+- [ ] Real workload (`cargo build` on a medium repo, `git status` here) — output reasonable.
+- [ ] `panda gain` works, savings comparable to pre-NPU baseline.
+
+### Regression risk areas
+
+- The `with_execution_providers` retry-on-failure path (ORT builders are consumed; rebuild from scratch).
+- Daemon `preload_model` now does ~5s extra on NPU; the `daemon start` parent-sleep heuristic of 200ms may print "started" before the daemon is serving. Acceptable (clients retry via `try_auto_start`), confirm end-to-end.
+
+## Out of scope (follow-ups)
+
+1. Re-add the 9 opt-in embedding models (Snowflake-M-v2, Jina-code, Nomic, BGE family) by extending `model_registry()`.
+2. Re-add `embed-bench` to score the new models on the in-tree QA fixtures.
+3. Promote a different default model if the bench shows it justifies a breaking change.
+4. Optional GPU support — one extra arm in `ep_choice()` and one extra `OpenVINO::with_device_type("GPU")` build.

--- a/docs/superpowers/specs/2026-05-01-npu-raw-openvino-bypass-design.md
+++ b/docs/superpowers/specs/2026-05-01-npu-raw-openvino-bypass-design.md
@@ -1,0 +1,293 @@
+# NPU support via raw OpenVINO bypass — design
+
+**Date:** 2026-05-01
+**Status:** Draft for review
+**Branch (target):** continues on `feat/npu-on-ort` (already cut from upstream/main @ 9546fb6 v1.3.9)
+**Supersedes:** the runtime semantics of `2026-05-01-npu-on-upstream-ort-design.md`. The earlier spec's branch hygiene, config field, and resolver remain in place; only the embedder construction changes.
+
+## Problem
+
+The earlier "NPU on upstream ORT" approach wired up `ort` 2.0.0-rc.12's OpenVINO execution provider behind a `--features openvino` flag. Empirical verification on the target hardware (Intel Meteor Lake NPU 3720) showed that path cannot engage:
+
+- ORT's `download-binaries` mode bundles its own `libonnxruntime`, which collides with the OpenVINO provider plugins shipped in the user's existing distribution at `~/.local/share/ccr/onnxruntime/` — `std::bad_alloc` SIGABRT during inference.
+- Switching to `ort/load-dynamic` triggers a compile error inside ort itself (`SessionOptionsAppendExecutionProvider_VitisAI` field missing on the OrtApi struct).
+- `ort/copy-dylibs` makes no difference; the conflict is at runtime, not deployment.
+- `2.0.0-rc.12` is the latest published ort; no newer release exists, no older RC has the missing fix back-ported.
+- The current branch's session creation silently succeeds without engaging the EP, then logs `[panda] embedder: ... on NPU` while CPU runs — the false-NPU bug.
+
+The fork shipped a working NPU path before the upstream merge: `ccr-core/src/ov_embed.rs` (preserved on `archive/pre-upstream-merge`) used the OpenVINO C API directly via the `openvino-rs` crates, with disk cache, async infer-request pool, and a process-wide degradation flag. It worked on this exact hardware.
+
+## Approach
+
+Restore the raw-OpenVINO bypass on top of the Approach A scaffolding. The current branch's resolver, config field, daemon wiring, and observability hook are kept verbatim. The `--features openvino` flag is repointed: instead of activating ORT's OpenVINO EP, it pulls in the `openvino-rs` crates and wires a direct `OvEmbedder` ahead of the ORT-CPU path.
+
+Concretely:
+
+1. The four `#[cfg(feature = "openvino")]` blocks in `summarizer.rs`'s `MiniLmEmbedder::new` revert to upstream's flat `[CPU]` builder. The Approach A "EP list with CPU fallback retry" code is deleted as dead weight; nothing constructs the ORT OpenVINO EP anymore.
+2. `ccr-core/src/ov_embed.rs` is restored from `archive/pre-upstream-merge`, trimmed to the two models in upstream's current registry (`AllMiniLML6V2`, `AllMiniLML12V2`).
+3. `summarizer.rs` gains a `#[cfg(feature = "openvino")] static OV_EMBEDDER: OnceCell<Option<ov_embed::OvEmbedder>>` plus a `get_ov_embedder()` accessor.
+4. `embed_and_normalize` checks `current_ep() == "npu"` and `get_ov_embedder().is_some()` *before* falling through to ORT-CPU.
+5. The daemon's `daemon_main` eagerly preloads the OV embedder when configured, so the multi-second NPU compile happens once at daemon start.
+
+## Non-goals
+
+- Re-adding the 9 opt-in models from `archive/pre-upstream-merge`. Separate follow-up; this spec ships with the same 2-model registry as upstream.
+- Re-adding `embed-bench` and `bench_summarize`. Separate follow-up.
+- Reactivating the ORT OpenVINO EP path for any future ort release. If/when ort fixes the rc.12 issues, that's a one-line Cargo.toml flip; not in scope here.
+- GPU acceleration. The OpenVINO API supports it (`DeviceType::GPU`), but this spec hard-codes `DeviceType::NPU`.
+- Multi-process NPU coordination. The OpenVINO blob cache at `~/.cache/panda/openvino` lets parallel `panda` invocations share compile work, but no explicit fan-out/fan-in is added.
+- Replacing `MiniLmEmbedder` with a trait/enum hierarchy. Two embedder structs coexist as static singletons; dispatch is a single `if let Some(...)` in `embed_and_normalize`.
+
+## Architecture
+
+```
+panda CLI (hook/run/filter)
+  │
+  ├── embed_and_normalize(texts)
+  │     1. try daemon_embed via Unix socket  ── owns warm NPU session
+  │     2. (feature gated) if current_ep()=="npu" and get_ov_embedder().is_some()
+  │            → OvEmbedder::embed (raw OpenVINO C API, NPU device)
+  │     3. fall through: embed_direct → MiniLmEmbedder (ort CPU only)
+  │
+  └── panda daemon start
+        └── daemon_main →
+              set_model_name / set_ort_threads / set_execution_provider
+              (if feature on and ep == "npu") preload_ov_embedder()
+                                              ↓
+                                              OvEmbedder::try_new
+                                                ├ ov_lib_path() finds
+                                                │   ~/.local/share/ccr/onnxruntime/libopenvino_c.so
+                                                │   (or OPENVINO_LIB_PATH override)
+                                                ├ Core::new + cache_dir + THROUGHPUT hint
+                                                ├ resolve_model_files (hf-hub, reused from upstream)
+                                                ├ static-shape reshape [1, seq_len]
+                                                ├ core.compile_model(NPU)   ← cached at ~/.cache/panda/openvino
+                                                └ pre-allocate InferRequest pool (size = OPTIMAL_NUMBER_OF_INFER_REQUESTS, clamp 1..=8)
+              preload_model() (CPU embedder, cheap fallback insurance)
+              bind socket, accept loop
+```
+
+Single integration point at runtime: `embed_and_normalize`'s ordered cascade.
+Single integration point at config-time: `current_ep()` (unchanged from Approach A).
+
+## File-level changes
+
+### `ccr-core/Cargo.toml`
+
+Replace the `openvino = ["ort/openvino"]` feature wiring with `openvino-rs` deps:
+
+```toml
+[dependencies]
+# ... existing unchanged ...
+openvino = { git = "https://github.com/intel/openvino-rs", rev = "e25f1f848edc",
+             features = ["runtime-linking"], optional = true }
+openvino-sys = { git = "https://github.com/intel/openvino-rs", rev = "e25f1f848edc",
+                 features = ["runtime-linking"], optional = true }
+
+[features]
+default = []
+openvino = ["dep:openvino", "dep:openvino-sys"]
+```
+
+The git rev matches `archive/pre-upstream-merge` — proven working on this hardware. `runtime-linking` means no link-time dependency on `libopenvino_c.so`; the binary builds on CI machines without OpenVINO installed.
+
+### `ccr/Cargo.toml`
+
+`openvino = ["panda-core/openvino"]` forwarding feature stays unchanged.
+
+### `ccr-core/src/lib.rs`
+
+Add module declaration (next to existing module list):
+
+```rust
+#[cfg(feature = "openvino")]
+pub(crate) mod ov_embed;
+```
+
+### `ccr-core/src/ov_embed.rs` (new)
+
+Near-verbatim port of `archive/pre-upstream-merge:ccr-core/src/ov_embed.rs`. Public surface:
+
+- `pub fn is_degraded() -> bool`
+- `pub fn mark_degraded(reason: &str)`
+- `pub fn ov_lib_path() -> Option<PathBuf>`
+- `pub fn model_seq_len(name: &str) -> Option<usize>` — replaces the old `model_onnx_info`. Returns `Some(128)` for `AllMiniLML6V2`/`AllMiniLML12V2`, `None` otherwise.
+- `pub struct OvEmbedder { ... }` with `pub fn try_new(onnx_path, tokenizer_path, seq_len) -> Result<Self>` and `pub fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>>`.
+
+Drops `find_fastembed_onnx` — replaced by reusing `summarizer::resolve_model_files()` (which already returns `(model_path, tokenizer_path)` via `hf_hub`). `model_onnx_info`'s 16-model registry shrinks to a `model_seq_len` lookup with two arms; the HF repo strings are no longer needed because `hf_hub` is upstream's job.
+
+Keeps the proven NPU bits intact:
+- `~/.cache/panda/openvino` blob cache directory.
+- `PERFORMANCE_HINT=THROUGHPUT` and the `PANDA_NPU_PRECISION` env override.
+- Static shape reshape `[1, seq_len]`.
+- `Mutex<Vec<InferRequest>>` async pool, sized by `OPTIMAL_NUMBER_OF_INFER_REQUESTS` clamped to `[1, 8]`.
+- `DEGRADED: AtomicBool` process-wide flag, `mark_degraded` is idempotent and prints once.
+
+### `ccr-core/src/summarizer.rs`
+
+Four feature-gated additions:
+
+```rust
+#[cfg(feature = "openvino")]
+static OV_EMBEDDER: OnceCell<Option<crate::ov_embed::OvEmbedder>> = OnceCell::new();
+
+#[cfg(feature = "openvino")]
+fn get_ov_embedder() -> Option<&'static crate::ov_embed::OvEmbedder> {
+    if crate::ov_embed::is_degraded() { return None; }
+    OV_EMBEDDER.get_or_init(|| {
+        let name = get_model_name();
+        let (onnx, tok) = match resolve_model_files(name) {
+            Ok(v) => v,
+            Err(e) => { eprintln!("[panda] OV bypass: model fetch failed: {e}"); return None; }
+        };
+        let seq_len = match crate::ov_embed::model_seq_len(name) {
+            Some(s) => s,
+            None => { eprintln!("[panda] OV bypass: no seq_len for {name}; CPU fallback"); return None; }
+        };
+        match crate::ov_embed::OvEmbedder::try_new(&onnx, &tok, seq_len) {
+            Ok(e) => {
+                eprintln!("[panda] embedder: {} on NPU (raw OpenVINO)", name);
+                Some(e)
+            }
+            Err(err) => { eprintln!("[panda] OV bypass init failed: {err}"); None }
+        }
+    }).as_ref()
+}
+
+#[cfg(feature = "openvino")]
+pub fn preload_ov_embedder() -> Option<()> {
+    get_ov_embedder().map(|_| ())
+}
+
+#[cfg(feature = "openvino")]
+pub fn ov_embedder_is_active() -> bool {
+    OV_EMBEDDER.get().and_then(|o| o.as_ref()).is_some()
+}
+```
+
+`embed_and_normalize` adds the dispatch:
+
+```rust
+fn embed_and_normalize(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
+    #[cfg(unix)]
+    if let Some(embeddings) = crate::embed_client::daemon_embed(&texts, true) {
+        return Ok(embeddings);
+    }
+    #[cfg(feature = "openvino")]
+    if current_ep() == "npu" {
+        if let Some(ov) = get_ov_embedder() {
+            let mut v = ov.embed(&texts)?;
+            for e in &mut v { l2_normalize(e); }
+            return Ok(v);
+        }
+    }
+    #[cfg(unix)] apply_nice_once();
+    embed_direct(texts)
+}
+```
+
+`embed_direct` (called by daemon worker) gets the same OV check at its top, before reaching `MiniLmEmbedder`.
+
+`MiniLmEmbedder::new` reverts to upstream's flat `[CPU]` builder — the Approach A closure-based EP-list retry is deleted (~50 lines). The "on CPU (ort)" log line moves into the `get_or_init` of `MODEL_CACHE` so it fires only when ORT actually constructs the session.
+
+### `ccr/src/cmd/daemon.rs`
+
+Add the eager preload:
+
+```rust
+panda_core::summarizer::set_execution_provider(&config.global.execution_provider);
+#[cfg(feature = "openvino")]
+if panda_core::summarizer::current_ep() == "npu" {
+    let _ = panda_core::summarizer::preload_ov_embedder();
+}
+if panda_core::summarizer::preload_model().is_err() {
+    std::process::exit(1);
+}
+```
+
+`current_ep()` becomes `pub` (was `pub(crate)`) so the daemon crate can call it.
+
+### `ccr/src/main.rs`
+
+No change beyond Approach A's existing `set_execution_provider` call. The foreground path lazy-initialises OV on first embed via `get_ov_embedder` — there's no benefit to eager init in a short-lived process.
+
+### `README.md`
+
+Rewrite the NPU section. Old text described the ORT EP path; new text describes the raw bypass. Key changes:
+- Build command unchanged: `cargo build --release --features openvino`.
+- Drop the `libopenvino_c.so` discoverability paragraph; mention `OPENVINO_LIB_PATH` env override and the default search list (`~/.local/share/ccr/onnxruntime/libopenvino_c.so`, then `/usr/lib`, etc.).
+- Add a one-liner about the disk cache at `~/.cache/panda/openvino`.
+- Mention `PANDA_NPU_STRICT=1` for diagnosing degradation.
+
+## Data flow
+
+**Cold start (daemon, NPU):** `panda daemon start` → fork → flock pid → load config → `set_*` → `preload_ov_embedder()` → `ov_lib_path()` resolves `~/.local/share/ccr/onnxruntime/libopenvino_c.so` → `Core::new` → set `THROUGHPUT` hint + cache dir → `resolve_model_files("AllMiniLML6V2")` returns `(onnx_path, tokenizer.json)` via hf_hub → reshape ONNX inputs to `[1, 128]` → `compile_model(NPU)` (3–10s cold; <500ms warm via cache) → query `OPTIMAL_NUMBER_OF_INFER_REQUESTS` → preallocate 4 `InferRequest`s → eprintln embedder line → bind socket. Subsequent `daemon_embed` calls embed via the warm async pool, parallelising across the NPU's two tiles.
+
+**Cold start (in-process, NPU):** Same flow but lazy. First `panda` invocation that hits the BERT stage pays the compile cost; subsequent processes hit the disk cache.
+
+**Degraded state:** `OvEmbedder::embed` retries once on transient failure, calls `mark_degraded("...")` on second failure. `DEGRADED` flips. `get_ov_embedder` returns `None` for the rest of process lifetime. Next call falls through to `embed_direct` → `MiniLmEmbedder` → CPU. One `eprintln!` line marks the transition.
+
+## Error handling
+
+| Failure | Detection | Behaviour |
+|---|---|---|
+| Built without `--features openvino`, config says `"npu"` | `current_ep()` returns "cpu" (compile-time gate) | One-time stderr warning. CPU runs. |
+| `libopenvino_c.so` missing | `ov_lib_path()` returns `None` → `try_new` errors | Log, cache `None` in `OV_EMBEDDER`, CPU runs. |
+| OpenVINO present, NPU device absent | `compile_model(NPU)` errors | Log, cache `None`, CPU runs. |
+| NPU runtime failure mid-embed | `OvEmbedder::embed` retry, then `mark_degraded` | One log line, `DEGRADED=true`, all subsequent embeds → CPU. |
+| `PANDA_NPU_STRICT=1` set | New env check inside `get_ov_embedder` and on `mark_degraded` | Surface errors as `Err` from `embed_and_normalize` rather than degrading silently. |
+| Daemon crashes | Existing `daemon_embed` returns None | Existing fallthrough to in-process; `try_auto_start` restarts. |
+| `~/.cache/panda/openvino` write fails | `set_property(NPU, CacheDir, ...)` errors | Log warning; continue without persistent cache (compile every cold start). |
+| OpenVINO driver upgrade invalidates cache | OV plugin handles transparently | First post-upgrade run pays cold compile; subsequent warm. |
+
+**Observability** — the false-NPU bug is fixed: only the OV path prints `on NPU`; the ORT path prints `on CPU`. Each fires from inside its own constructor (or `get_or_init` closure), so the line reflects what actually loaded.
+
+## Testing
+
+### Unit tests
+
+Existing (kept): `ep_resolver_tests::*` (4) and `execution_provider_tests::*` (2) — resolver layer is unchanged.
+
+New in `ccr-core/src/ov_embed.rs`:
+
+3. `ov_lib_path_returns_none_when_nothing_present` — clear `OPENVINO_LIB_PATH`, set `HOME` to a temp dir, assert `None`.
+4. `ov_lib_path_honours_env_var` — set `OPENVINO_LIB_PATH=<tempfile>`, assert it's found. Also test the directory form.
+5. `model_seq_len_returns_known_models` — `Some(128)` for the two registry entries, `None` otherwise.
+6. `is_degraded_starts_false_marks_true_idempotent` — flips, then second call no-ops.
+
+These run on every CI machine — no openvino-sys, no NPU.
+
+### Feature-gated integration tests (`ccr-core/tests/npu_smoke.rs`)
+
+Replace Approach A's tests with sharper assertions:
+
+7. `npu_smoke_actually_uses_npu` — embed three strings, assert shape 3×384 and L2-normalised, **plus** `summarizer::ov_embedder_is_active() == true`. The Approach A version of this test passed even when CPU silently ran; this version cannot.
+8. `npu_falls_back_to_cpu_when_libopenvino_missing` — `OPENVINO_LIB_PATH=/dev/null`, embed succeeds, `ov_embedder_is_active() == false`.
+
+Both gated `#[cfg(feature = "openvino")]`, both skip silently unless `OPENVINO_NPU_AVAILABLE=1`.
+
+### Manual verification
+
+- [ ] `cargo build --release -p panda` (no feature) — clean.
+- [ ] `cargo build --release -p panda --features openvino` — clean compile + link (runtime-linking means no OV lib required to build).
+- [ ] `cargo test -p panda-core` — all tests pass, no NPU touched.
+- [ ] `OPENVINO_NPU_AVAILABLE=1 cargo test -p panda-core --features openvino --test npu_smoke -- --nocapture` — both tests pass; first run prints multi-second cold time, second run sub-second (proves disk cache).
+- [ ] `panda daemon start` with `execution_provider="npu"` — daemon log shows `[panda] embedder: AllMiniLML6V2 on NPU (raw OpenVINO)` and `[panda] NPU infer-request pool size: 4`.
+- [ ] `panda run cargo build` — filtered output, no degradation messages.
+- [ ] `panda gain` — non-zero savings, comparable to CPU baseline.
+- [ ] **Latency probe:** time `panda run cargo build` 3× back-to-back. Cold pays compile (or hits cache); runs 2-3 should be visibly faster than CPU baseline.
+- [ ] `PANDA_NPU_STRICT=1 OPENVINO_LIB_PATH=/dev/null panda daemon start` — daemon fails or logs hard error, doesn't silently degrade.
+- [ ] Force degradation (kill NPU device or load a corrupt model) — `[panda] NPU embedder failed (...); falling back to CPU` appears once; subsequent embeds quiet on CPU.
+
+### Regression risk
+
+- `#[cfg(feature = "openvino")]` proliferation across `summarizer.rs` — concentrate in 4 marked spots only.
+- `Mutex<Vec<InferRequest>>` lock contention if daemon's worker threadpool > pool size.
+- The `~/.cache/panda/openvino` invalidation behaviour on driver upgrade — confirm with one manual test cycle if practical.
+
+## Out of scope (follow-ups)
+
+1. Restore the 9 opt-in models. `model_seq_len` grows from 2 to 16 entries; nothing else changes structurally.
+2. Restore `embed-bench` against the 9-model registry on NPU.
+3. Optional GPU device selection (one new arm in `ep_choice` plus a `DeviceType::GPU` variant in `OvEmbedder`).
+4. Re-attempt the ORT OpenVINO EP path when ort releases a fix for `load-dynamic` — at that point the choice is whether to keep both or pick one.


### PR DESCRIPTION
## Summary
Merges upstream's ORT migration (PR #5) while restoring Intel NPU acceleration via a raw OpenVINO bypass that sits alongside the upstream ORT-CPU path.

## Approach
Approach A (using ORT's OpenVINO EP) was implemented and empirically failed on Meteor Lake NPU 3720 — silent CPU fallback under one config, std::bad_alloc SIGABRT under another, ort 2.0.0-rc.12 vitis.rs compile errors with load-dynamic. Pivoted to Approach B: when execution_provider = "npu", bypass ORT entirely and call OpenVINO's C API via openvino-rs directly. ORT-CPU stays exactly as upstream merged it.

## What's in
- openvino cargo feature (off by default) on panda-core, forwarded by panda
- ccr-core/src/ov_embed.rs — raw OpenVINO embedder ported from archive/pre-upstream-merge, trimmed to AllMiniLM L6/L12, with HF-hub model resolution
- OV_EMBEDDER static + get/preload/is_active accessors in summarizer
- OV dispatch wired ahead of ORT-CPU in embed_and_normalize and embed_direct
- Daemon eagerly preloads OV at startup so the multi-second NPU compile happens once
- PANDA_NPU_STRICT=1 makes OV init failure fatal in the daemon (default is graceful CPU fallback)
- Two integration tests in their own binaries (OnceCell isolation): npu_smoke asserts ov_embedder_is_active() to catch silent fallback; npu_fallback verifies CPU fallback when libopenvino_c.so is hidden
- Unit tests for ov_embed pure functions
- README NPU section rewritten for the runtime-linking model + cache + strict-mode flag

## Verification
On Meteor Lake NPU 3720 with OPENVINO_NPU_AVAILABLE=1:
- cargo test -p panda-core --features openvino --test npu_smoke --test npu_fallback — both pass
- Real workload `panda run cargo build` logs `[panda] embedder: AllMiniLML6V2 on NPU (raw OpenVINO)`
- Cold init 762ms / warm embed 543ms; OV InferRequest pool size 4 (matches NPU 3720's 2 tiles × 2)

## Default behavior unchanged
Without the openvino feature flag, this is upstream + workspace docs and the panda.toml field. CPU users see no change.

## Spec & plan
- docs/superpowers/specs/2026-05-01-npu-raw-openvino-bypass-design.md
- docs/superpowers/plans/2026-05-01-npu-raw-openvino-bypass.md
