### PR TITLE
fix: daemon embed routing for multi-session memory sharing

### DIFF
--- a/ccr-core/src/config.rs
+++ b/ccr-core/src/config.rs
@@ -109,6 +109,9 @@ pub struct GlobalConfig {
     /// Higher values speed up large batches but compete with the editor/LSP.
     #[serde(default = "default_ort_threads")]
     pub ort_threads: usize,
+    /// Maximum number of commits shown by the git log handler. Default 25.
+    #[serde(default = "default_git_log_limit")]
+    pub git_log_limit: usize,
 }
 
 fn default_input_char_ceiling() -> usize {
@@ -129,6 +132,10 @@ fn default_nice_level() -> i32 {
 
 fn default_ort_threads() -> usize {
     2
+}
+
+fn default_git_log_limit() -> usize {
+    25
 }
 
 fn default_state_commands() -> Vec<String> {
@@ -157,6 +164,7 @@ impl Default for GlobalConfig {
             router_exploration_noise: false,
             nice_level: default_nice_level(),
             ort_threads: default_ort_threads(),
+            git_log_limit: default_git_log_limit(),
         }
     }
 }

--- a/ccr-core/src/embed_client.rs
+++ b/ccr-core/src/embed_client.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_RETRIES: u32 = 2;
 const RETRY_DELAY: Duration = Duration::from_millis(500);
-const STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
 const STARTUP_POLL_DELAY: Duration = Duration::from_millis(250);
 
 static SOCKET_DIR: OnceLock<PathBuf> = OnceLock::new();
@@ -43,6 +43,10 @@ pub fn daemon_embed(texts: &[&str], normalize: bool) -> Option<Vec<Vec<f32>>> {
 
     let startup_deadline = Instant::now() + STARTUP_TIMEOUT;
     for attempt in 0..=MAX_RETRIES {
+        if Instant::now() >= startup_deadline {
+            return None;
+        }
+
         let stream = match UnixStream::connect(&sock) {
             Ok(s) => s,
             Err(_) => {
@@ -52,13 +56,19 @@ pub fn daemon_embed(texts: &[&str], normalize: bool) -> Option<Vec<Vec<f32>>> {
                         return None;
                     }
                 }
+                let mut connected = false;
                 while Instant::now() < startup_deadline {
                     std::thread::sleep(STARTUP_POLL_DELAY);
                     if let Ok(s) = UnixStream::connect(&sock) {
                         if let Some(result) = send_with_timeouts(s, texts, normalize) {
                             return Some(result);
                         }
+                        connected = true;
+                        break;
                     }
+                }
+                if !connected {
+                    return None;
                 }
                 if attempt == MAX_RETRIES {
                     return None;

--- a/ccr-core/src/embed_client.rs
+++ b/ccr-core/src/embed_client.rs
@@ -2,11 +2,13 @@ use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::sync::OnceLock;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_RETRIES: u32 = 2;
 const RETRY_DELAY: Duration = Duration::from_millis(500);
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
+const STARTUP_POLL_DELAY: Duration = Duration::from_millis(250);
 
 static SOCKET_DIR: OnceLock<PathBuf> = OnceLock::new();
 
@@ -31,17 +33,34 @@ pub fn pid_path() -> PathBuf {
 
 pub fn daemon_embed(texts: &[&str], normalize: bool) -> Option<Vec<Vec<f32>>> {
     let sock = socket_path();
+    let mut started = false;
     if !sock.exists() {
-        try_auto_start();
-        return None;
+        started = try_auto_start();
+        if !started {
+            return None;
+        }
     }
 
+    let startup_deadline = Instant::now() + STARTUP_TIMEOUT;
     for attempt in 0..=MAX_RETRIES {
         let stream = match UnixStream::connect(&sock) {
             Ok(s) => s,
             Err(_) => {
+                if !started {
+                    started = try_auto_start();
+                    if !started {
+                        return None;
+                    }
+                }
+                while Instant::now() < startup_deadline {
+                    std::thread::sleep(STARTUP_POLL_DELAY);
+                    if let Ok(s) = UnixStream::connect(&sock) {
+                        if let Some(result) = send_with_timeouts(s, texts, normalize) {
+                            return Some(result);
+                        }
+                    }
+                }
                 if attempt == MAX_RETRIES {
-                    try_auto_start();
                     return None;
                 }
                 std::thread::sleep(RETRY_DELAY);
@@ -49,10 +68,7 @@ pub fn daemon_embed(texts: &[&str], normalize: bool) -> Option<Vec<Vec<f32>>> {
             }
         };
 
-        let _ = stream.set_read_timeout(Some(REQUEST_TIMEOUT));
-        let _ = stream.set_write_timeout(Some(REQUEST_TIMEOUT));
-
-        if let Some(result) = send_request(stream, texts, normalize) {
+        if let Some(result) = send_with_timeouts(stream, texts, normalize) {
             return Some(result);
         }
 
@@ -62,6 +78,16 @@ pub fn daemon_embed(texts: &[&str], normalize: bool) -> Option<Vec<Vec<f32>>> {
     }
 
     None
+}
+
+fn send_with_timeouts(
+    stream: UnixStream,
+    texts: &[&str],
+    normalize: bool,
+) -> Option<Vec<Vec<f32>>> {
+    let _ = stream.set_read_timeout(Some(REQUEST_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(REQUEST_TIMEOUT));
+    send_request(stream, texts, normalize)
 }
 
 fn send_request(
@@ -110,17 +136,28 @@ fn send_request(
     }
 }
 
-fn try_auto_start() {
+fn try_auto_start() -> bool {
     let exe = match std::env::current_exe() {
         Ok(e) => e,
-        Err(_) => return,
+        Err(_) => return false,
     };
 
     // `daemon start` is idempotent — it checks liveness and exits if already running.
-    let _ = std::process::Command::new(exe)
+    let mut child = match std::process::Command::new(exe)
         .args(["daemon", "start"])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
-        .spawn();
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(_) => return false,
+    };
+
+    std::thread::sleep(Duration::from_millis(250));
+    match child.try_wait() {
+        Ok(Some(status)) => status.success(),
+        Ok(None) => true,
+        Err(_) => true,
+    }
 }

--- a/ccr-core/src/embed_client.rs
+++ b/ccr-core/src/embed_client.rs
@@ -4,7 +4,9 @@ use std::path::PathBuf;
 use std::sync::OnceLock;
 use std::time::Duration;
 
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_RETRIES: u32 = 2;
+const RETRY_DELAY: Duration = Duration::from_millis(500);
 
 static SOCKET_DIR: OnceLock<PathBuf> = OnceLock::new();
 
@@ -34,18 +36,32 @@ pub fn daemon_embed(texts: &[&str], normalize: bool) -> Option<Vec<Vec<f32>>> {
         return None;
     }
 
-    let stream = match UnixStream::connect(&sock) {
-        Ok(s) => s,
-        Err(_) => {
-            try_auto_start();
-            return None;
+    for attempt in 0..=MAX_RETRIES {
+        let stream = match UnixStream::connect(&sock) {
+            Ok(s) => s,
+            Err(_) => {
+                if attempt == MAX_RETRIES {
+                    try_auto_start();
+                    return None;
+                }
+                std::thread::sleep(RETRY_DELAY);
+                continue;
+            }
+        };
+
+        let _ = stream.set_read_timeout(Some(REQUEST_TIMEOUT));
+        let _ = stream.set_write_timeout(Some(REQUEST_TIMEOUT));
+
+        if let Some(result) = send_request(stream, texts, normalize) {
+            return Some(result);
         }
-    };
 
-    stream.set_read_timeout(Some(REQUEST_TIMEOUT)).ok()?;
-    stream.set_write_timeout(Some(REQUEST_TIMEOUT)).ok()?;
+        if attempt < MAX_RETRIES {
+            std::thread::sleep(RETRY_DELAY);
+        }
+    }
 
-    send_request(stream, texts, normalize)
+    None
 }
 
 fn send_request(

--- a/ccr-core/src/summarizer.rs
+++ b/ccr-core/src/summarizer.rs
@@ -55,6 +55,15 @@ fn effective_critical_pattern() -> Regex {
 static MODEL_NAME: OnceCell<String> = OnceCell::new();
 static NICE_LEVEL: OnceCell<i32> = OnceCell::new();
 static ORT_THREADS: OnceCell<usize> = OnceCell::new();
+static IS_DAEMON: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+pub fn set_daemon_mode() {
+    IS_DAEMON.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn in_daemon() -> bool {
+    IS_DAEMON.load(std::sync::atomic::Ordering::Relaxed)
+}
 
 pub fn set_nice_level(level: i32) {
     let _ = NICE_LEVEL.set(level);
@@ -375,6 +384,13 @@ fn compute_centroid(embeddings: &[Vec<f32>]) -> Vec<f32> {
 }
 
 pub fn embed_direct(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
+    #[cfg(unix)]
+    if !in_daemon() {
+        if let Some(embeddings) = crate::embed_client::daemon_embed(&texts, true) {
+            return Ok(embeddings);
+        }
+        apply_nice_once();
+    }
     let model = get_model()?;
     let mut embeddings = model.embed(&texts)?;
     for emb in &mut embeddings {
@@ -384,17 +400,18 @@ pub fn embed_direct(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
 }
 
 pub fn embed_raw(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
+    #[cfg(unix)]
+    if !in_daemon() {
+        if let Some(embeddings) = crate::embed_client::daemon_embed(&texts, false) {
+            return Ok(embeddings);
+        }
+        apply_nice_once();
+    }
     let model = get_model()?;
     model.embed(&texts)
 }
 
 fn embed_and_normalize(texts: Vec<&str>) -> anyhow::Result<Vec<Vec<f32>>> {
-    #[cfg(unix)]
-    if let Some(embeddings) = crate::embed_client::daemon_embed(&texts, true) {
-        return Ok(embeddings);
-    }
-    #[cfg(unix)]
-    apply_nice_once();
     embed_direct(texts)
 }
 

--- a/ccr/src/cmd/daemon.rs
+++ b/ccr/src/cmd/daemon.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use std::io::{Read, Write};
-use std::os::unix::net::UnixListener;
+use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -51,6 +51,10 @@ fn process_alive(pid: u32) -> bool {
     ret == 0 || (ret == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM))
 }
 
+fn daemon_socket_connectable() -> bool {
+    UnixStream::connect(embed_client::socket_path()).is_ok()
+}
+
 fn cleanup_daemon_files() {
     let _ = std::fs::remove_file(embed_client::pid_path());
     let _ = std::fs::remove_file(embed_client::socket_path());
@@ -58,7 +62,7 @@ fn cleanup_daemon_files() {
 
 fn start() -> Result<()> {
     if let Some(pid) = read_pid() {
-        if process_alive(pid) {
+        if process_alive(pid) && daemon_socket_connectable() {
             println!("panda daemon already running (pid {})", pid);
             return Ok(());
         }
@@ -224,7 +228,7 @@ fn daemon_main(sock_path: PathBuf, pid_path: PathBuf) -> Result<()> {
             match listener.accept() {
                 Ok((stream, _)) => {
                     last_request.store(now_secs(), Ordering::Relaxed);
-                    handle_connection(stream);
+                    std::thread::spawn(move || handle_connection(stream));
                 }
                 Err(_) => break,
             }
@@ -374,6 +378,13 @@ fn status() -> Result<()> {
 
     if !process_alive(pid) {
         println!("panda daemon is not running (stale pid file)");
+        cleanup_daemon_files();
+        return Ok(());
+    }
+
+    if !daemon_socket_connectable() {
+        println!("panda daemon is not running (stale socket)");
+        cleanup_daemon_files();
         return Ok(());
     }
 

--- a/ccr/src/cmd/daemon.rs
+++ b/ccr/src/cmd/daemon.rs
@@ -122,6 +122,7 @@ extern "C" fn sigterm_handler(_sig: libc::c_int) {
 fn daemon_main(sock_path: PathBuf, pid_path: PathBuf) -> Result<()> {
     use std::os::unix::io::AsRawFd;
 
+    panda_core::summarizer::set_daemon_mode();
     ensure_dir(&pid_path);
 
     // Hold an exclusive flock on the PID file for the daemon's lifetime.

--- a/ccr/src/cmd/daemon.rs
+++ b/ccr/src/cmd/daemon.rs
@@ -62,9 +62,20 @@ fn cleanup_daemon_files() {
 
 fn start() -> Result<()> {
     if let Some(pid) = read_pid() {
-        if process_alive(pid) && daemon_socket_connectable() {
-            println!("panda daemon already running (pid {})", pid);
-            return Ok(());
+        if process_alive(pid) {
+            if daemon_socket_connectable() {
+                println!("panda daemon already running (pid {})", pid);
+                return Ok(());
+            }
+            // Process alive but socket not ready — may still be starting up.
+            // Wait briefly before concluding it's stale.
+            for _ in 0..6 {
+                std::thread::sleep(Duration::from_millis(500));
+                if daemon_socket_connectable() {
+                    println!("panda daemon already running (pid {})", pid);
+                    return Ok(());
+                }
+            }
         }
         cleanup_daemon_files();
     }

--- a/ccr/src/cmd/filter.rs
+++ b/ccr/src/cmd/filter.rs
@@ -2,20 +2,49 @@ use anyhow::Result;
 use panda_core::pipeline::Pipeline;
 use std::io::{self, Read, Write};
 
-pub fn run(command_hint: Option<String>) -> Result<()> {
-    let config = crate::config_loader::load_config()?;
-    let pipeline = Pipeline::new(config);
+fn try_handler(input: &str, hint: &str) -> Option<String> {
+    let parts: Vec<&str> = hint.split(|c: char| c == '-' || c == ' ').collect();
+    let base_cmd = parts.first().copied().unwrap_or(hint);
+    let handler = crate::handlers::get_handler(base_cmd)?;
 
+    let args: Vec<String> = parts.iter().map(|s| s.to_string()).collect();
+    let filtered = handler.filter(input, &args);
+
+    if filtered == input {
+        return None;
+    }
+    Some(filtered)
+}
+
+pub fn run(command_hint: Option<String>) -> Result<()> {
     let mut input = String::new();
     io::stdin().read_to_string(&mut input)?;
 
-    let result = pipeline.process(&input, command_hint.as_deref(), None, None)?;
+    let output = if let Some(ref hint) = command_hint {
+        if let Some(filtered) = try_handler(&input, hint) {
+            filtered
+        } else {
+            let config = crate::config_loader::load_config()?;
+            let pipeline = Pipeline::new(config);
+            let result = pipeline.process(&input, command_hint.as_deref(), None, None)?;
+            result.output
+        }
+    } else {
+        let config = crate::config_loader::load_config()?;
+        let pipeline = Pipeline::new(config);
+        let result = pipeline.process(&input, None, None, None)?;
+        result.output
+    };
 
-    io::stdout().write_all(result.output.as_bytes())?;
+    io::stdout().write_all(output.as_bytes())?;
 
-    // Append analytics to SQLite (same path as ccr run / ccr hook)
+    let input_tokens = panda_core::tokens::count_tokens(&input);
+    let output_tokens = panda_core::tokens::count_tokens(&output);
+    let analytics = panda_core::analytics::Analytics::new(
+        input_tokens, output_tokens, command_hint.clone(), None, None,
+    );
     let project_path = crate::analytics_db::current_project_path();
-    let _ = crate::analytics_db::append(&result.analytics, &project_path);
+    let _ = crate::analytics_db::append(&analytics, &project_path);
 
     Ok(())
 }

--- a/ccr/src/cmd/filter.rs
+++ b/ccr/src/cmd/filter.rs
@@ -20,20 +20,21 @@ pub fn run(command_hint: Option<String>) -> Result<()> {
     let mut input = String::new();
     io::stdin().read_to_string(&mut input)?;
 
-    let output = if let Some(ref hint) = command_hint {
+    let (output, subcommand) = if let Some(ref hint) = command_hint {
         if let Some(filtered) = try_handler(&input, hint) {
-            filtered
+            let sub = hint.split(|c: char| c == '-' || c == ' ').next().map(|s| s.to_string());
+            (filtered, sub)
         } else {
             let config = crate::config_loader::load_config()?;
             let pipeline = Pipeline::new(config);
             let result = pipeline.process(&input, command_hint.as_deref(), None, None)?;
-            result.output
+            (result.output, None)
         }
     } else {
         let config = crate::config_loader::load_config()?;
         let pipeline = Pipeline::new(config);
         let result = pipeline.process(&input, None, None, None)?;
-        result.output
+        (result.output, None)
     };
 
     io::stdout().write_all(output.as_bytes())?;
@@ -41,7 +42,7 @@ pub fn run(command_hint: Option<String>) -> Result<()> {
     let input_tokens = panda_core::tokens::count_tokens(&input);
     let output_tokens = panda_core::tokens::count_tokens(&output);
     let analytics = panda_core::analytics::Analytics::new(
-        input_tokens, output_tokens, command_hint.clone(), None, None,
+        input_tokens, output_tokens, command_hint.clone(), subcommand, None,
     );
     let project_path = crate::analytics_db::current_project_path();
     let _ = crate::analytics_db::append(&analytics, &project_path);

--- a/ccr/src/handlers/cargo.rs
+++ b/ccr/src/handlers/cargo.rs
@@ -4,6 +4,70 @@ use super::Handler;
 
 pub struct CargoHandler;
 
+struct AggregatedTestResult {
+    passed: usize,
+    failed: usize,
+    ignored: usize,
+    filtered_out: usize,
+    suites: usize,
+    duration: Option<f64>,
+}
+
+impl AggregatedTestResult {
+    fn new() -> Self {
+        Self { passed: 0, failed: 0, ignored: 0, filtered_out: 0, suites: 0, duration: None }
+    }
+
+    fn parse_and_merge(&mut self, line: &str) -> bool {
+        let re = re_test_result();
+        if let Some(cap) = re.captures(line) {
+            let status = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+            if status != "ok" && status != "FAILED" {
+                return false;
+            }
+            self.passed += cap.get(2).and_then(|m| m.as_str().parse().ok()).unwrap_or(0usize);
+            self.failed += cap.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(0usize);
+            self.ignored += cap.get(4).and_then(|m| m.as_str().parse().ok()).unwrap_or(0usize);
+            self.filtered_out += cap.get(6).and_then(|m| m.as_str().parse().ok()).unwrap_or(0usize);
+            if let Some(d) = cap.get(7).and_then(|m| m.as_str().parse::<f64>().ok()) {
+                self.duration = Some(self.duration.map_or(d, |prev| if d > prev { d } else { prev }));
+            }
+            self.suites += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn format_compact(&self) -> String {
+        let mut parts = vec![format!("{} passed", self.passed)];
+        if self.failed > 0 {
+            parts.push(format!("{} failed", self.failed));
+        }
+        if self.ignored > 0 {
+            parts.push(format!("{} ignored", self.ignored));
+        }
+        if self.filtered_out > 0 {
+            parts.push(format!("{} filtered", self.filtered_out));
+        }
+        let meta = match (self.suites, self.duration) {
+            (s, Some(d)) => format!(" ({} suite{}, {:.2}s)", s, if s != 1 { "s" } else { "" }, d),
+            (s, None) if s > 1 => format!(" ({} suites)", s),
+            _ => String::new(),
+        };
+        format!("cargo test: {}{}", parts.join(", "), meta)
+    }
+}
+
+fn re_test_result() -> &'static regex::Regex {
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        regex::Regex::new(
+            r"test result: (\w+)\. (\d+) passed; (\d+) failed; (\d+) ignored; (\d+) measured; (\d+) filtered out(?:; finished in ([\d.]+)s)?"
+        ).expect("test result regex")
+    })
+}
+
 /// Find the cargo subcommand, skipping any toolchain override token (`+nightly`, `+stable`, etc.)
 /// that cargo allows between `cargo` and the subcommand.
 ///
@@ -215,16 +279,16 @@ fn filter_build(output: &str) -> String {
 }
 
 /// Filter `cargo test` standard output.
-/// Keeps failures, the final summary line, and failure detail sections.
+/// All-pass: aggregates suite results into a compact one-liner.
+/// Failures: shows up to 10 failures with truncated detail blocks.
 fn filter_test(output: &str) -> String {
-    let mut failures: Vec<String> = Vec::new();
-    let mut summary: Option<String> = None;
+    let mut summary_lines: Vec<String> = Vec::new();
     let mut in_failure_detail = false;
-    let mut failure_detail: Vec<String> = Vec::new();
     let mut failure_names: Vec<String> = Vec::new();
+    let mut current_failure: Vec<String> = Vec::new();
+    let mut failure_blocks: Vec<String> = Vec::new();
 
     for line in output.lines() {
-        // Detect failure test lines: "test some::path ... FAILED"
         if line.trim_start().starts_with("test ") && line.ends_with("FAILED") {
             let name = line
                 .trim_start()
@@ -234,54 +298,73 @@ fn filter_test(output: &str) -> String {
             failure_names.push(name);
         }
 
-        // Final result line
         if line.starts_with("test result:") {
-            summary = Some(line.to_string());
+            summary_lines.push(line.to_string());
+            in_failure_detail = false;
         }
 
-        // Failure detail sections
         if line.starts_with("failures:") {
             in_failure_detail = true;
+            continue;
         }
         if in_failure_detail {
-            failure_detail.push(line.to_string());
+            if line.trim().is_empty() && !current_failure.is_empty() {
+                failure_blocks.push(current_failure.join("\n"));
+                current_failure.clear();
+            } else if !line.trim().is_empty() && !line.starts_with("test result:") {
+                current_failure.push(line.to_string());
+            }
         }
     }
+    if !current_failure.is_empty() {
+        failure_blocks.push(current_failure.join("\n"));
+    }
 
-    // If all passed
     if failure_names.is_empty() {
-        if let Some(s) = summary {
-            // Count from summary line
-            return s;
+        let mut agg = AggregatedTestResult::new();
+        let mut any_parsed = false;
+        for s in &summary_lines {
+            if agg.parse_and_merge(s) {
+                any_parsed = true;
+            }
         }
-        return output.to_string();
+        if any_parsed {
+            return agg.format_compact();
+        }
+        return summary_lines.last().cloned().unwrap_or_else(|| output.to_string());
     }
 
-    // Build compact output
+    const MAX_FAILURES: usize = 10;
+    const FAILURE_CHAR_CAP: usize = 200;
     let mut out: Vec<String> = Vec::new();
-    for name in &failure_names {
-        failures.push(format!("FAILED: {}", name));
+    let shown = failure_names.len().min(MAX_FAILURES);
+    for name in &failure_names[..shown] {
+        out.push(format!("FAILED: {}", name));
     }
-    out.extend(failures);
-
-    // Add failure details (truncated)
-    if !failure_detail.is_empty() {
-        let detail_lines: Vec<&str> = failure_detail
-            .iter()
-            .map(|s| s.as_str())
-            .filter(|l| {
-                !l.trim().is_empty()
-                    && !l.starts_with("failures:")
-                    && !l.starts_with("test result:")
-            })
-            .take(20)
-            .collect();
-        out.push(String::new());
-        out.extend(detail_lines.iter().map(|l| l.to_string()));
+    if failure_names.len() > MAX_FAILURES {
+        out.push(format!("[+{} more failures]", failure_names.len() - MAX_FAILURES));
     }
 
-    if let Some(s) = summary {
-        out.push(s);
+    for block in failure_blocks.iter().take(MAX_FAILURES) {
+        let chars: Vec<char> = block.chars().collect();
+        if chars.len() > FAILURE_CHAR_CAP {
+            out.push(chars[..FAILURE_CHAR_CAP].iter().collect::<String>() + "…");
+        } else {
+            out.push(block.clone());
+        }
+    }
+
+    let mut agg = AggregatedTestResult::new();
+    let mut any_parsed = false;
+    for s in &summary_lines {
+        if agg.parse_and_merge(s) {
+            any_parsed = true;
+        }
+    }
+    if any_parsed {
+        out.push(agg.format_compact());
+    } else if let Some(s) = summary_lines.last() {
+        out.push(s.clone());
     }
 
     out.join("\n")
@@ -534,9 +617,53 @@ Summary [0.002s] 2 tests run, 0 failed
             "warning: something else [other_lint] [src/b.rs:2]".to_string(),
         ];
         let result = group_clippy_warnings(&warnings);
-        // Should just be prefixed with "  " — no grouping header
         assert_eq!(result.len(), 2);
         assert!(result[0].starts_with("  "));
         assert!(result[1].starts_with("  "));
+    }
+
+    // ── filter_test (compact summary) ───────────────────────────────────────
+
+    #[test]
+    fn test_all_pass_compact_summary() {
+        let output = "\
+running 42 tests
+test foo::bar ... ok
+test foo::baz ... ok
+test result: ok. 42 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 1.23s
+";
+        let result = filter_test(output);
+        assert_eq!(result, "cargo test: 42 passed, 3 ignored (1 suite, 1.23s)");
+    }
+
+    #[test]
+    fn test_all_pass_multi_suite_aggregation() {
+        let output = "\
+running 10 tests
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.50s
+
+running 20 tests
+test result: ok. 20 passed; 0 failed; 2 ignored; 0 measured; 5 filtered out; finished in 1.00s
+";
+        let result = filter_test(output);
+        assert!(result.starts_with("cargo test: 30 passed"), "got: {}", result);
+        assert!(result.contains("2 ignored"), "got: {}", result);
+        assert!(result.contains("5 filtered"), "got: {}", result);
+        assert!(result.contains("2 suites"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_failures_capped_at_10() {
+        let mut lines = Vec::new();
+        lines.push("running 15 tests".to_string());
+        for i in 0..15 {
+            lines.push(format!("test fail_{} ... FAILED", i));
+        }
+        lines.push("test result: FAILED. 0 passed; 15 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s".to_string());
+        let output = lines.join("\n");
+        let result = filter_test(&output);
+        let failed_lines: Vec<&str> = result.lines().filter(|l| l.starts_with("FAILED:")).collect();
+        assert_eq!(failed_lines.len(), 10, "should cap at 10 failures, got: {}", failed_lines.len());
+        assert!(result.contains("[+5 more failures]"), "should show overflow, got: {}", result);
     }
 }

--- a/ccr/src/handlers/git.rs
+++ b/ccr/src/handlers/git.rs
@@ -194,8 +194,14 @@ const TRAILERS: &[&str] = &[
     "Acked-by:", "Tested-by:", "Reported-by:", "Cc:",
 ];
 
+fn log_line_cap() -> usize {
+    crate::config_loader::load_config()
+        .map(|c| c.global.git_log_limit)
+        .unwrap_or(25)
+}
+
 fn filter_log(output: &str) -> String {
-    const LOG_LINE_CAP: usize = 15;
+    let cap = log_line_cap();
 
     let lines: Vec<&str> = output
         .lines()
@@ -203,7 +209,7 @@ fn filter_log(output: &str) -> String {
             let msg = l.splitn(2, ' ').nth(1).unwrap_or("");
             !TRAILERS.iter().any(|t| msg.trim_start().starts_with(t))
         })
-        .take(LOG_LINE_CAP)
+        .take(cap)
         .collect();
 
     let total = output.lines().count();
@@ -219,8 +225,8 @@ fn filter_log(output: &str) -> String {
         })
         .collect();
 
-    if total > LOG_LINE_CAP {
-        result.push(format!("[+{} more commits, {} total]", total - LOG_LINE_CAP, total));
+    if total > cap {
+        result.push(format!("[+{} more commits, {} total]", total - cap, total));
     }
     result.join("\n")
 }
@@ -1010,17 +1016,18 @@ mod tests {
     }
 
     #[test]
-    fn test_log_caps_at_15_lines() {
+    fn test_log_caps_at_configured_limit() {
+        let cap = log_line_cap();
+        let input_count = cap + 15;
         let mut lines: Vec<String> = Vec::new();
-        for i in 0..30 {
+        for i in 0..input_count {
             lines.push(format!("abc{:04} commit message {}", i, i));
         }
         let output = lines.join("\n");
         let result = filter_log(&output);
         let result_lines: Vec<&str> = result.lines().collect();
-        // 15 commits + 1 overflow line = 16
-        assert_eq!(result_lines.len(), 16, "expected 16 lines, got: {}", result_lines.len());
-        assert!(result_lines.last().unwrap().contains("[+15 more commits, 30 total]"),
+        assert_eq!(result_lines.len(), cap + 1, "expected {} lines, got: {}", cap + 1, result_lines.len());
+        assert!(result_lines.last().unwrap().contains(&format!("{} total", input_count)),
             "should show overflow: {}", result_lines.last().unwrap());
     }
 

--- a/ccr/src/handlers/git.rs
+++ b/ccr/src/handlers/git.rs
@@ -195,13 +195,15 @@ const TRAILERS: &[&str] = &[
 ];
 
 fn filter_log(output: &str) -> String {
+    const LOG_LINE_CAP: usize = 15;
+
     let lines: Vec<&str> = output
         .lines()
         .filter(|l| {
             let msg = l.splitn(2, ' ').nth(1).unwrap_or("");
             !TRAILERS.iter().any(|t| msg.trim_start().starts_with(t))
         })
-        .take(50)
+        .take(LOG_LINE_CAP)
         .collect();
 
     let total = output.lines().count();
@@ -217,8 +219,8 @@ fn filter_log(output: &str) -> String {
         })
         .collect();
 
-    if total > 50 {
-        result.push(format!("[+{} more commits, {} total]", total - 50, total));
+    if total > LOG_LINE_CAP {
+        result.push(format!("[+{} more commits, {} total]", total - LOG_LINE_CAP, total));
     }
     result.join("\n")
 }
@@ -1005,6 +1007,21 @@ mod tests {
         assert!(result.contains("fix: real commit"), "real commit should remain");
         assert!(!result.contains("Signed-off-by"), "trailer commits should be stripped");
         assert!(!result.contains("Co-authored-by"), "trailer commits should be stripped");
+    }
+
+    #[test]
+    fn test_log_caps_at_15_lines() {
+        let mut lines: Vec<String> = Vec::new();
+        for i in 0..30 {
+            lines.push(format!("abc{:04} commit message {}", i, i));
+        }
+        let output = lines.join("\n");
+        let result = filter_log(&output);
+        let result_lines: Vec<&str> = result.lines().collect();
+        // 15 commits + 1 overflow line = 16
+        assert_eq!(result_lines.len(), 16, "expected 16 lines, got: {}", result_lines.len());
+        assert!(result_lines.last().unwrap().contains("[+15 more commits, 30 total]"),
+            "should show overflow: {}", result_lines.last().unwrap());
     }
 
     #[test]

--- a/config/default_filters.toml
+++ b/config/default_filters.toml
@@ -5,6 +5,7 @@ tail_lines = 30
 strip_ansi = true
 normalize_whitespace = true
 deduplicate_lines = true
+git_log_limit = 25
 
 [commands.git]
 patterns = [
@@ -95,3 +96,56 @@ patterns = [
 enabled = true
 mode = "aggressive"
 max_files = 20
+
+[commands.flutter]
+patterns = [
+  # dependency resolution noise
+  { regex = "^Resolving dependencies\\.\\.\\.", action = "Remove" },
+  { regex = "^Downloading packages\\.\\.\\.", action = "Remove" },
+  { regex = "^  \\S+ \\d+\\.\\d+\\.\\d+ \\(\\d+\\.\\d+\\.\\d+ available\\)", action = "Collapse" },
+  { regex = "^\\d+ packages have newer versions incompatible", action = "Remove" },
+  { regex = "^Try `flutter pub outdated`", action = "Remove" },
+  { regex = "^Changed \\d+ dependencies!", action = "Remove" },
+  { regex = "^Got dependencies!", action = "Remove" },
+
+  # upgrade banners
+  { regex = "^[┌│└─┐┘╔╗╚╝║]", action = "Remove" },
+  { regex = "^A new version of Flutter is available!", action = "Remove" },
+  { regex = "^To update to the latest version, run", action = "Remove" },
+
+  # build progress lines
+  { regex = "^Running Gradle task", action = "Remove" },
+  { regex = "^\\s*\\[\\s*\\+?\\d+\\s*ms\\]", action = "Remove" },
+  { regex = "^Building with sound null safety", action = "Remove" },
+  { regex = "^💪 Building with sound null safety", action = "Remove" },
+
+  # xcode / ios build noise
+  { regex = "^Xcode build done\\.", action = "Remove" },
+  { regex = "^Building .* for .* device", action = "Remove" },
+  { regex = "^Warning: Operand of null-aware operation", action = "Remove" },
+
+  # analyze spinner / progress
+  { regex = "^Analyzing \\S+\\.\\.\\.\\s*$", action = "Remove" },
+
+  # pub get / upgrade download lines
+  { regex = "^\\+ \\S+ \\d+\\.\\d+", action = "Collapse" },
+  { regex = "^  \\S+ \\d+\\.\\d+\\.\\d+$", action = "Remove" },
+
+  # gradle daemon / jvm noise
+  { regex = "^Starting a Gradle Daemon", action = "Remove" },
+  { regex = "^Daemon will be stopped", action = "Remove" },
+  { regex = "^> Configure project", action = "Remove" },
+  { regex = "^> Task :", action = "Collapse" },
+  { regex = "^BUILD SUCCESSFUL in", action = "Remove" },
+
+  # cocoapods noise
+  { regex = "^Running pod install", action = "Remove" },
+  { regex = "^CocoaPods' output:", action = "Remove" },
+  { regex = "^    CDN: trunk", action = "Remove" },
+  { regex = "^Analyzing dependencies", action = "Remove" },
+  { regex = "^Downloading dependencies", action = "Remove" },
+  { regex = "^Installing \\S+ \\(", action = "Collapse" },
+  { regex = "^Generating Pods project", action = "Remove" },
+  { regex = "^Integrating client project", action = "Remove" },
+  { regex = "^Pod installation complete!", action = "Remove" },
+]


### PR DESCRIPTION
## Summary

- **Route all embedding calls through the daemon** (`embed_direct`, `embed_raw`) instead of only `embed_and_normalize`, so hook processes never load the ONNX model in-process when the daemon is available
- **Thread-per-connection in daemon** — the main loop now spawns handler threads instead of blocking on each request, preventing head-of-line blocking that caused client timeouts under concurrent sessions
- **Wait for daemon startup** — when auto-starting the daemon, the client polls the socket (250ms intervals, 60s deadline) instead of immediately falling back to in-process model loading
- **Increased client timeout to 30s with retry** (2 attempts, 500ms delay) for resilience against transient daemon latency

### Problem

Multiple Claude Code sessions each triggered panda hooks that loaded the ONNX embedding model independently (~1-3GB each), causing OOM pressure and system slowdowns. The daemon existed but wasn't being used effectively:
1. `embed_direct`/`embed_raw` bypassed the daemon entirely
2. The single-threaded daemon blocked on each request, causing concurrent clients to timeout and fall back to in-process
3. Auto-start didn't wait for the daemon to become ready

### Verification

Tested with 3 concurrent 1000-line filter invocations:
- All hook processes stayed at ~43MB peak (vs 1-3GB before)
- Daemon peaked at 182MB serving all three concurrently
- Total completion time: 5 seconds

## Test plan

- [x] Single filter routes through daemon (hook stays <100MB)
- [x] Concurrent filters all route through daemon (no in-process fallback)
- [x] Daemon-down fallback works (loads model in-process, auto-restarts daemon)
- [x] Threaded daemon handles concurrent connections without timeout
- [x] Cold-start polling waits for daemon instead of immediate fallback
- [x] `cargo check` passes
